### PR TITLE
Feature/ken/sync arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [Unreleased](#unreleased
+- [1.0.6.1- 2025-07-03](#1061---2025-07-03)
 - [1.0.6- 2025-06-30](#106---2025-06-30)
 - [1.0.5- 2025-05-30](#105---2025-05-30)
 - [1.0.4- 2025-04-28](#104---2025-04-28)
@@ -41,6 +42,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
 
 ---
+
+## [1.0.6.1] - 2025-07-03
+
+### Fixed
+Bug Fix default_http_client and add async ARC broadcasting example 
+
+- Replaced `default_sync_http_client` with `DefaultHttpClient` in `default_http_client`.
+- Introduced a new `test_async_arc.py` example demonstrating asynchronous ARC broadcasting and transaction status checking.
 
 ## [1.0.6] - 2025-06-30
 

--- a/bsv/__init__.py
+++ b/bsv/__init__.py
@@ -20,4 +20,4 @@ from .encrypted_message import *
 from .signed_message import *
 
 
-__version__ = '1.0.6'
+__version__ = '1.0.6.1'

--- a/bsv/http_client.py
+++ b/bsv/http_client.py
@@ -137,4 +137,4 @@ def default_sync_http_client() -> SyncHttpClient:
 
 
 def default_http_client() -> HttpClient:
-    return default_sync_http_client()
+    return DefaultHttpClient()

--- a/examples/test_async_arc.py
+++ b/examples/test_async_arc.py
@@ -1,0 +1,80 @@
+from idlelib.configdialog import changes
+import asyncio
+
+from bsv import (
+    Transaction,
+    TransactionInput,
+    TransactionOutput,
+    PrivateKey,
+    P2PKH,
+    BroadcastResponse,
+    ARC,ARCConfig
+)
+
+"""
+Simple example of synchronous ARC broadcasting and status checking.
+"""
+# ARC_URL='https://api.taal.com/arc'
+
+async def main():
+# def main():
+
+    arc_config = ARCConfig(api_key="mainnet_2e3a7d0f845a5049b35e9dde98fc4271")
+    url = 'https://api.taal.com/arc'
+    arc = ARC(url, arc_config)
+    # Setup ARC broadcaster
+
+
+    # Create a simple transaction
+    private_key = PrivateKey("Kzpr5a6TmrXNw2NxSzt6GUonvcP8ABtfU17bdGEjxCufyxGMo9xV")
+    public_key = private_key.public_key()
+
+    source_tx = Transaction.from_hex(
+        "01000000013462125ff05a9150c25693bbb474a5cde58c0d4ce6ab265e746f523791e01462000000006a4730440220447ac5232e8eb25db0e004bc704a19bc33c9c7ef86070781078bce74e089be44022029195e8cc392bf7c5577dc477a90d157be0356d8fbb52eb66521f4eabe00dcf9412103e23c79a29b5e5f20127ec2286413510662d0e6befa29d669a623035122753d3affffffff013d000000000000001976a914047f8e69ca8eadec1b327d1b232cdaaffa200d1688ac00000000"
+    )
+
+    tx = Transaction(
+        [
+            TransactionInput(
+                source_transaction=source_tx,
+                source_txid=source_tx.txid(),
+                source_output_index=0,
+                unlocking_script_template=P2PKH().unlock(private_key),
+            )
+        ],
+        [
+            TransactionOutput(
+                locking_script=P2PKH().lock("1QnWY1CWbWGeqobBBoxdZZ3DDeWUC2VLn"),
+                change=True
+            )
+        ],
+    )
+
+    tx.fee()
+    tx.sign()
+    txid = tx.txid()
+    txhex = tx.hex()
+    print(f"Transaction ID: {txid}")
+    print(f"Transaction hex: {txhex}")
+    # Broadcast transaction
+    result = await arc.broadcast(tx)
+    # result = arc.sync_broadcast(tx)
+
+    if isinstance(result, BroadcastResponse):
+        print(f"Broadcast successful: {result.txid}")
+
+        # Check status
+        status = arc.check_transaction_status(result.txid)
+        print(f"Status: {status.get('txStatus', 'Unknown')}")
+
+        # Categorize status
+        category = arc.categorize_transaction_status(status)
+        print(f"Category: {category.get('status_category')}")
+
+    else:
+        print(f"Broadcast failed: {result.description}")
+
+
+if __name__ == "__main__":
+    # main()
+    asyncio.run(main())


### PR DESCRIPTION
## Description of Changes

### Fixed
Bug Fix default_http_client and add async ARC broadcasting example 

- Replaced `default_sync_http_client` with `DefaultHttpClient` in `default_http_client`.
- Introduced a new `test_async_arc.py` example demonstrating asynchronous ARC broadcasting and transaction status checking.


## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ x] I have updated `CHANGELOG.md` with my changes
- [ ] I have run the linter