### PR TITLE
Add configurable broadcasters and API key support for Taal ARC integr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
-- [Unreleased](#unreleased
+- [Unreleased](#unreleased)
+- [1.0.7- 2025-07-28](#107---2025-07-28)
 - [1.0.6.1- 2025-07-03](#1061---2025-07-03)
 - [1.0.6- 2025-06-30](#106---2025-06-30)
 - [1.0.5- 2025-05-30](#105---2025-05-30)
@@ -42,6 +43,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
 
 ---
+## [1.0.7] - 2025-07-28
+
+### Fixed
+- Implemented default broadcasters for GorillaPool mainnet and testnet.
+- - Updated examples to use new broadcaster functions.
+
+### Added
+- Introduced `default_broadcaster` with configurable options for testnet and custom ARC configurations.
+- Added function to set API key from constant.py for Taal mainnet and testnet (`taal_broadcaster`, `taal_testnet_broadcaster`).
+
+
 
 ## [1.0.6.1] - 2025-07-03
 

--- a/bsv/broadcaster.py
+++ b/bsv/broadcaster.py
@@ -29,6 +29,9 @@ class BroadcastFailure:
 
 
 class Broadcaster(ABC):
+    def __init__(self):
+        self.URL = None
+
     @abstractmethod
     async def broadcast(
             self, transaction: 'Transaction'

--- a/bsv/broadcasters/default.py
+++ b/bsv/broadcasters/default.py
@@ -1,6 +1,47 @@
-from .arc import ARC
+from typing import Union
+
+from .arc import ARC, ARCConfig
 from ..broadcaster import Broadcaster
+from ..constants import taal_mainnet_apikey, taal_testnet_apikey
 
 
-def default_broadcaster() -> Broadcaster:
-    return ARC('https://arc.taal.com')
+def default_broadcaster(
+        is_testnet: bool = False,
+        config: Union[ARCConfig, dict] = None
+) -> Broadcaster:
+    # Use existing broadcaster functions to get the base broadcaster
+    if is_testnet:
+        base_broadcaster = gorillapool_testnet_broadcaster()
+    else:
+        base_broadcaster = gorillapool_broadcaster()
+
+    # If no config provided, return the base broadcaster as-is
+    if config is None:
+        return base_broadcaster
+
+    # Convert dict config to ARCConfig if needed
+    if isinstance(config, dict):
+        config = ARCConfig(**config)
+
+    # Create new ARC instance with the same URL but custom config
+    return ARC(base_broadcaster.URL, config)
+
+
+def taal_broadcaster() -> Broadcaster:
+    # taal now requires an API key to broadcast transactions via ARC. If you would like to use it,
+    # please visit https://taal.com/ to register for one.
+    arc_config = ARCConfig(api_key=taal_mainnet_apikey)
+    return ARC('https://arc.taal.com', arc_config)
+
+def taal_testnet_broadcaster() -> Broadcaster:
+    # taal now requires an API key to broadcast transactions via ARC. If you would like to use it,
+    # please visit https://taal.com/ to register for one.
+    arc_config = ARCConfig(api_key=taal_testnet_apikey)
+    return ARC('https://arc-test.taal.com/', arc_config)
+
+def gorillapool_broadcaster() -> Broadcaster:
+    return ARC('https://arc.gorillapool.io')
+
+def gorillapool_testnet_broadcaster() -> Broadcaster:
+    return ARC('https://testnet.arc.gorillapool.io')
+

--- a/bsv/constants.py
+++ b/bsv/constants.py
@@ -47,6 +47,12 @@ class SIGHASH(int, Enum):
             cls.SINGLE_ANYONECANPAY_FORKID,
         ]
 
+#
+# ARC
+#
+#
+taal_mainnet_apikey = os.getenv('TAAL_MAINNET_APIKEY', '')
+taal_testnet_apikey = os.getenv('TAAL_TESTNET_APIKEY', '')
 
 #
 # P2PKH address

--- a/examples/test_async_arc.py
+++ b/examples/test_async_arc.py
@@ -8,29 +8,29 @@ from bsv import (
     PrivateKey,
     P2PKH,
     BroadcastResponse,
-    ARC,ARCConfig
 )
+from bsv.broadcasters.default import gorillapool_broadcaster, taal_broadcaster, default_broadcaster
+from bsv.broadcasters.arc import ARC
 
 """
 Simple example of synchronous ARC broadcasting and status checking.
 """
-# ARC_URL='https://api.taal.com/arc'
 
 async def main():
 # def main():
 
-    arc_config = ARCConfig(api_key="mainnet_2e3a7d0f845a5049b35e9dde98fc4271")
-    url = 'https://api.taal.com/arc'
-    arc = ARC(url, arc_config)
+    # arc = default_broadcaster()
+    # arc = taal_broadcaster()
+    arc = gorillapool_broadcaster()
     # Setup ARC broadcaster
 
 
     # Create a simple transaction
-    private_key = PrivateKey("Kzpr5a6TmrXNw2NxSzt6GUonvcP8ABtfU17bdGEjxCufyxGMo9xV")
+    private_key = PrivateKey("Kzpr5a6T-------------------dGEjxCufyxGMo9xV")
     public_key = private_key.public_key()
 
     source_tx = Transaction.from_hex(
-        "01000000013462125ff05a9150c25693bbb474a5cde58c0d4ce6ab265e746f523791e01462000000006a4730440220447ac5232e8eb25db0e004bc704a19bc33c9c7ef86070781078bce74e089be44022029195e8cc392bf7c5577dc477a90d157be0356d8fbb52eb66521f4eabe00dcf9412103e23c79a29b5e5f20127ec2286413510662d0e6befa29d669a623035122753d3affffffff013d000000000000001976a914047f8e69ca8eadec1b327d1b232cdaaffa200d1688ac00000000"
+        "0100000001d2e9a---------------------2aa43d541d38a94851700b6bb50348a8757cf0f318b4232aa1a6121a02203bc71f132461a046de661c33e0a0c93032dc085cb9591c8522b9eb0b296efcc9412103e23c79a29b5e5f20127ec2286413510662d0e6befa29d669a623035122753d3affffffff0134000000000000001976a914047f8e69ca8eadec1b327d1b232cdaaffa200d1688ac00000000"
     )
 
     tx = Transaction(
@@ -44,7 +44,7 @@ async def main():
         ],
         [
             TransactionOutput(
-                locking_script=P2PKH().lock("1QnWY1CWbWGeqobBBoxdZZ3DDeWUC2VLn"),
+                locking_script=P2PKH().lock("1KkyAC-----------pSUSx6QCPJ"),
                 change=True
             )
         ],
@@ -58,18 +58,21 @@ async def main():
     print(f"Transaction hex: {txhex}")
     # Broadcast transaction
     result = await arc.broadcast(tx)
-    # result = arc.sync_broadcast(tx)
+
+
+    # Check status
+
 
     if isinstance(result, BroadcastResponse):
-        print(f"Broadcast successful: {result.txid}")
+            print(f"Broadcast successful: {result.txid}")
 
-        # Check status
-        status = arc.check_transaction_status(result.txid)
-        print(f"Status: {status.get('txStatus', 'Unknown')}")
+            # Check status
+            status = arc.check_transaction_status(result.txid)
+            print(f"Status: {status.get('txStatus', 'Unknown')}")
 
-        # Categorize status
-        category = arc.categorize_transaction_status(status)
-        print(f"Category: {category.get('status_category')}")
+            # Categorize status
+            category = arc.categorize_transaction_status(status)
+            print(f"Category: {category.get('status_category')}")
 
     else:
         print(f"Broadcast failed: {result.description}")

--- a/examples/test_sync_arc.py
+++ b/examples/test_sync_arc.py
@@ -39,7 +39,7 @@ def main():
         ],
         [
             TransactionOutput(
-                locking_script=P2PKH().lock("1QnWY1CWbWGeqobBBoxdZZ3DDeWUC2VLn"),
+                locking_script=P2PKH().lock("1QnWY1---------3DDeWUC2VLn"),
                 change=True
             )
         ],


### PR DESCRIPTION
Add configurable broadcasters and API key support for Taal ARC integration

- Introduced `default_broadcaster` with configurable options for testnet and custom ARC configurations.
- Added API key-based broadcasters for Taal mainnet and testnet (`taal_broadcaster`, `taal_testnet_broadcaster`).
- Implemented default broadcasters for GorillaPool mainnet and testnet.
- Updated examples to use new broadcaster functions.

## Description of Changes

Provide a brief description of the changes you've made.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x ] All tests pass locally
- [x ] I have tested manually in my local environment

## Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [x ] I have updated `CHANGELOG.md` with my changes
- [ x] I have run the linter