### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bsv-blockchain/py-sdk/security/code-scanning/1](https://github.com/bsv-blockchain/py-sdk/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required. In this case, the workflow only needs to read repository contents (to check out code and run tests), so the minimal permissions block should be:

```yaml
permissions:
  contents: read
```

This block should be added at the top level of the workflow file (just after the `name:` and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed, as this is a configuration change in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
