### PR TITLE
bump to 1.0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Table of Contents
 
 - [Unreleased](#unreleased)
+- [1.0.7.1- 2025-07-28](#1071---2025-07-28)
 - [1.0.7- 2025-07-28](#107---2025-07-28)
 - [1.0.6.1- 2025-07-03](#1061---2025-07-03)
 - [1.0.6- 2025-06-30](#106---2025-06-30)
@@ -41,6 +42,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 - (Notify of any improvements related to security vulnerabilities or potential risks.)
+
+
+---
+## [1.0.7.1] - 2025-07-28
+
+### Changed
+- Incremented version in `__init__.py` to 1.0.7.1.
+
+### Security
+- Updated `aiohttp` and `setuptools` dependencies to use minimum version constraints.
+- Redacted private key in threshold signature example for security.
 
 ---
 ## [1.0.7] - 2025-07-28

--- a/bsv/__init__.py
+++ b/bsv/__init__.py
@@ -20,4 +20,4 @@ from .encrypted_message import *
 from .signed_message import *
 
 
-__version__ = '1.0.6.1'
+__version__ = '1.0.7.1'

--- a/examples/threshold_signature.py
+++ b/examples/threshold_signature.py
@@ -42,7 +42,7 @@ print(f"\nOriginal and recovered keys match: {is_keys_match}")
 #Check compatibility with Ts-sdk library
 
 
-ts_privatekey = "Kyig4TeeVahiY838EjiC72kzWkZXtjSj7m5axdQwPXRed57MiYUS"
+ts_privatekey = "Kyig4TeeVahiY8---------------QwPXRed57MiYUS"
 # Original Address: 179UiTpk4mqjQv6CJ4NoZqxwURym4uwV4v
 #these shares are created from the ts-sdk library.
 ts_shares = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pycryptodomex~=3.21.0
 coincurve~=20.0.0
-aiohttp~=3.11.11
+aiohttp>=3.12.14
 requests~=2.32.3
 pytest~=8.3.4
-setuptools~=75.6.0
+setuptools>=78.1.1


### PR DESCRIPTION
## Description of Changes
### Changed
- Incremented version in `__init__.py` to 1.0.7.1.

### Security
- Updated `aiohttp` and `setuptools` dependencies to use minimum version constraints.
- Redacted private key in threshold signature example for security.


## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [x] I have added new unit tests
- [x ] All tests pass locally
- [ x I have tested manually in my local environment

## Checklist:

- [ x] I have performed a self-review of my own code
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x ] I have updated `CHANGELOG.md` with my changes
- [x ] I have run the linter