### PR TITLE
fix incompatible protocol name length

### DIFF
--- a/bsv/wallet/key_deriver.py
+++ b/bsv/wallet/key_deriver.py
@@ -21,8 +21,10 @@ class Protocol:
     protocol: str
     
     def __init__(self, security_level: int, protocol: str):
-        if not isinstance(protocol, str) or len(protocol) < 5 or len(protocol) > 400:
-            raise ValueError("protocol names must be 5-400 characters")
+        # Allow 3-400 characters to match TS/Go (e.g., "ctx" is valid in tests)
+        # This matches _validate_protocol() behavior
+        if not isinstance(protocol, str) or len(protocol) < 3 or len(protocol) > 400:
+            raise ValueError("protocol names must be 3-400 characters")
         self.security_level = security_level
         self.protocol = protocol
 


### PR DESCRIPTION
## Description of Changes

Protocoll class has contradiction in protocol name.
__init__ requires minimum length of 5, instead _validate_protocol allows 3.
Minimum length 3 is compatible with TypeScript and Go implementation.

## Linked Issues / Tickets


## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [ ] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run the linter