### PR TITLE
Fix issue that unintended installataion of tests/bsv module due to configuration error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ with open('bsv/__init__.py', 'r') as f:
 
 setup(
     version=version,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('tests', 'tests.*')),
 )


### PR DESCRIPTION
## Description of Changes

Current `setup.py` excludes `tests` directory, but we also need `tests.*` to exclude all test codes.
This results unintended installation of `test/bsv` module for site-packages.
It causes confilict to test code for any package..
This PR fixes this problem.

## Linked Issues / Tickets
N/A

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [ ] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run the linter