### PR TITLE
Ver.2.xxxbetap

### DIFF
--- a/bsv/script/script.py
+++ b/bsv/script/script.py
@@ -61,27 +61,56 @@ class Script:
         """Backward compatibility property for script field."""
         return self.script_bytes
 
+    def _update_conditional_depth(self, op: bytes, depth: int) -> int:
+        """Update conditional block depth based on opcode."""
+        if op == OpCode.OP_IF or op == OpCode.OP_NOTIF or op == OpCode.OP_VERIF or op == OpCode.OP_VERNOTIF:
+            return depth + 1
+        if op == OpCode.OP_ENDIF:
+            return max(0, depth - 1)
+        return depth
+
+    def _handle_op_return(self, reader: Reader, chunk: ScriptChunk) -> bool:
+        """Handle OP_RETURN opcode. Returns True if parsing should terminate."""
+        remaining_length = len(reader.getvalue()) - reader.tell()
+        if remaining_length > 0:
+            chunk.data = reader.read_bytes(remaining_length)
+        else:
+            chunk.data = None
+        self.chunks.append(chunk)
+        return True  # Terminate parsing
+
+    def _read_push_data(self, reader: Reader, op: bytes) -> Optional[bytes]:
+        """Read push data based on opcode. Returns data bytes or None."""
+        if b"\x01" <= op <= b"\x4b":
+            return reader.read_bytes(int.from_bytes(op, "big"))
+        if op == OpCode.OP_PUSHDATA1:
+            length = reader.read_uint8()
+            return reader.read_bytes(length) if length is not None else None
+        if op == OpCode.OP_PUSHDATA2:
+            length = reader.read_uint16_le()
+            return reader.read_bytes(length) if length is not None else None
+        if op == OpCode.OP_PUSHDATA4:
+            length = reader.read_uint32_le()
+            return reader.read_bytes(length) if length is not None else None
+        return None
+
     def _build_chunks(self):
         self.chunks = []
         reader = Reader(self.script_bytes)
+        in_conditional_block = 0
+
         while not reader.eof():
             op = reader.read_bytes(1)
             chunk = ScriptChunk(op)
-            data = None
-            if b"\x01" <= op <= b"\x4b":
-                data = reader.read_bytes(int.from_bytes(op, "big"))
-            elif op == OpCode.OP_PUSHDATA1:  # 0x4c
-                length = reader.read_uint8()
-                if length is not None:
-                    data = reader.read_bytes(length)
-            elif op == OpCode.OP_PUSHDATA2:
-                length = reader.read_uint16_le()
-                if length is not None:
-                    data = reader.read_bytes(length)
-            elif op == OpCode.OP_PUSHDATA4:
-                length = reader.read_uint32_le()
-                if length is not None:
-                    data = reader.read_bytes(length)
+
+            in_conditional_block = self._update_conditional_depth(op, in_conditional_block)
+
+            if op == OpCode.OP_RETURN and in_conditional_block == 0:
+                if self._handle_op_return(reader, chunk):
+                    break
+                continue
+
+            data = self._read_push_data(reader, op)
             chunk.data = data
             self.chunks.append(chunk)
 

--- a/tests/bsv/script/test_scripts.py
+++ b/tests/bsv/script/test_scripts.py
@@ -89,6 +89,54 @@ def test_op_return():
         OpReturn().lock([1])
 
 
+def test_op_return_chunk_parsing():
+    """
+    Test that OP_RETURN correctly terminates script parsing and treats remaining bytes as data.
+    This verifies the fix for issue where scripts starting with 0x00 6a were incorrectly parsed.
+    """
+    # Test case: OP_FALSE OP_RETURN with data (the bug case)
+    # Script: 00 (OP_FALSE) 6a (OP_RETURN) 04 (push 4 bytes) 54657374 ("Test")
+    script = Script("006a0454657374")
+    chunks = list(script.chunks)
+
+    # Should parse as 2 chunks, not 3
+    assert len(chunks) == 2, f"Expected 2 chunks, got {len(chunks)}"
+
+    # First chunk: OP_FALSE
+    assert chunks[0].op == b"\x00"
+    assert chunks[0].data is None
+
+    # Second chunk: OP_RETURN with all remaining data
+    assert chunks[1].op == b"\x6a"
+    assert chunks[1].data == b"\x04Test"
+
+    # Test case: OP_RETURN with data (no OP_FALSE prefix)
+    script2 = Script("6a0454657374")
+    chunks2 = list(script2.chunks)
+
+    assert len(chunks2) == 1, f"Expected 1 chunk, got {len(chunks2)}"
+    assert chunks2[0].op == b"\x6a"
+    assert chunks2[0].data == b"\x04Test"
+
+    # Test case: OP_RETURN with no data
+    script3 = Script("6a")
+    chunks3 = list(script3.chunks)
+
+    assert len(chunks3) == 1
+    assert chunks3[0].op == b"\x6a"
+    assert chunks3[0].data is None
+
+    # Test case: OP_FALSE OP_RETURN with no data
+    script4 = Script("006a")
+    chunks4 = list(script4.chunks)
+
+    assert len(chunks4) == 2
+    assert chunks4[0].op == b"\x00"
+    assert chunks4[0].data is None
+    assert chunks4[1].op == b"\x6a"
+    assert chunks4[1].data is None
+
+
 def test_p2pk():
     private_key = PrivateKey("L5agPjZKceSTkhqZF2dmFptT5LFrbr6ZGPvP7u4A6dvhTrr71WZ9")
     public_key = private_key.public_key()


### PR DESCRIPTION
# Fix OP_RETURN Script Parsing - Port to v2.0 Branch

## Description of Changes

This PR ports the critical OP_RETURN parsing bug fix from v1.0.11p to the v2.0 branch (`Ver.2.xxxbetap`). The fix ensures scripts starting with `0x00 6a` (OP_FALSE OP_RETURN) are correctly parsed.

### Bug Fix: OP_RETURN Handling
- **Issue**: Scripts containing `OP_RETURN` (0x6a) were not properly terminating script parsing. When `OP_RETURN` was encountered, the parser continued to parse subsequent bytes as opcodes instead of treating them as data.
- **Fix**: Implemented proper `OP_RETURN` handling following the TypeScript SDK pattern:
  - Added conditional block tracking (`OP_IF`, `OP_NOTIF`, `OP_VERIF`, `OP_VERNOTIF` / `OP_ENDIF`)
  - `OP_RETURN` outside conditional blocks now terminates parsing and treats all remaining bytes as data
  - `OP_RETURN` inside conditional blocks is treated as a normal opcode
- **Impact**: Scripts like `006a0454657374` now correctly parse as 2 chunks instead of 3

### Code Quality Improvements
1. **Reduced Cognitive Complexity**:
   - Extracted `_update_conditional_depth()` helper method (reduces complexity in `_build_chunks()`)
   - Extracted `_handle_op_return()` helper method
   - Extracted `_read_push_data()` helper method
   - All methods now meet SonarQube complexity requirements (≤15)

2. **Code Structure**:
   - Adapted fix to work with v2.0 branch structure (uses `script_bytes` instead of `_bytes`)
   - Maintains backward compatibility with existing v2.0 code

3. **Test Improvements**:
   - Added comprehensive `test_op_return_chunk_parsing()` test that verifies the bug fix
   - Test located in `tests/bsv/script/test_scripts.py` (v2.0 test structure)

## Linked Issues / Tickets

Ports fix from: v1.0.11p branch
Related to: https://github.com/bsv-blockchain/py-sdk/issues/135

## Testing Procedure

### Unit Tests Added
- ✅ **`test_op_return_chunk_parsing()`**: Comprehensive test covering:
  - OP_FALSE OP_RETURN with data (the bug case: `006a0454657374`)
  - OP_RETURN with data (no OP_FALSE prefix)
  - OP_RETURN with no data
  - OP_FALSE OP_RETURN with no data

### Test Results
pytest tests/bsv/script/test_scripts.py::test_op_return_chunk_parsing -v
# Result: PASSED