### PR TITLE
Fix/lookup resolver binary parse

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@ Describe the tests you've added or any testing steps you've taken.
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have updated `CHANGELOG.md` with my changes
-- [ ] I have run the linter
+- [ ] I have run the linter and formatter (`ruff check . && black --check .` — both must pass with no errors)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [2.1.5 - 2026-06-05](#215---2026-06-05)
 - [2.1.4 - 2026-05-27](#214---2026-05-27)
 - [2.1.2 - 2026-05-20](#212---2026-05-20)
 - [2.1.1 - 2026-05-19](#211---2026-05-19)
@@ -28,6 +29,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [2.1.5] - 2026-06-05
+
+### Fixed
+
+- Fixed JSON response path in `HTTPSOverlayLookupFacilitator.lookup()` discarding parsed data — `response.json()` result was being thrown away, always returning an empty `LookupAnswer`. Added `_parse_json_response()` to properly construct output-list from JSON responses.
+- Added `_coerce_bytes()` to handle `beef`/`context` encoding differences across overlay server implementations: TS overlay-express sends `number[]`, Go overlay-services sends base64 strings (Go `[]byte` JSON default), hex strings also accepted.
+- Fixed binary lookup response parser: replaced `read_var_int()` with `read_var_int_num()` and added per-output BEEF reconstruction from the trailing combined BEEF.
+
+### Documentation
+
+- Added Ruff/Black linting instructions to `CLAUDE.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md` for external contributors and AI tools.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,27 @@ pytest tests/test_transaction.py
 pytest tests/bsv/auth/test_auth_peer_basic.py
 ```
 
+### Linting & Formatting (Required before commit/PR)
+
+All code must pass Ruff and Black before committing. Run these commands and fix any errors before creating a commit or pull request:
+
+```bash
+# Lint with Ruff (fix auto-fixable issues)
+ruff check --fix .
+
+# Format with Black
+black .
+
+# Verify no remaining issues
+ruff check .
+```
+
+Configuration is in `pyproject.toml` under `[tool.ruff]` and `[tool.black]`. Install dev dependencies with:
+
+```bash
+pip install -e ".[dev]"
+```
+
 ### Building the Package
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,21 +54,41 @@ contributors to adhere to.
 
 2. **Commit Your Changes**: Make your changes and commit them. Commit messages should be clear and concise to explain what was done.
 
-3. **Run Tests**: Ensure all tests pass and check coverage: `pytest --cov=bsv --cov-branch --cov-report=html`.
+3. **Run Linter & Formatter**: `ruff check --fix . && black .` — then verify with `ruff check . && black --check .`.
 
-4. **Documentation**: All code must be fully annotated with comments.
+4. **Run Tests**: Ensure all tests pass and check coverage: `pytest --cov=bsv --cov-branch --cov-report=html`.
 
-5. **Push to Your Fork**: `git push origin your-new-branch`.
+5. **Documentation**: All code must be fully annotated with comments.
 
-6. **Open a Pull Request**: Go to your fork on GitHub and click "New Pull Request". Fill out the PR template, explaining your changes.
+6. **Push to Your Fork**: `git push origin your-new-branch`.
 
-7. **Code Review**: At least two maintainers must review and approve the PR before it's merged. Address any feedback or changes requested.
+7. **Open a Pull Request**: Go to your fork on GitHub and click "New Pull Request". Fill out the PR template, explaining your changes.
 
-8. **Merge**: Once approved, the PR will be merged into the main branch.
+8. **Code Review**: At least two maintainers must review and approve the PR before it's merged. Address any feedback or changes requested.
+
+9. **Merge**: Once approved, the PR will be merged into the main branch.
 
 ## Coding Conventions
 
-- **Code Style**: We use [PEP 8](https://peps.python.org/pep-0008/) for our Python coding style.
+- **Code Style**: We use [PEP 8](https://peps.python.org/pep-0008/) for our Python coding style, enforced by **Ruff** (linter) and **Black** (formatter).
+
+- **Linting & Formatting**: All code must pass Ruff and Black before submitting a PR. Run the following commands from the project root:
+
+  ```bash
+  # Fix auto-fixable lint issues
+  ruff check --fix .
+
+  # Format code
+  black .
+
+  # Verify no remaining lint errors
+  ruff check .
+
+  # Verify formatting is correct
+  black --check .
+  ```
+
+  Configuration for both tools is in `pyproject.toml` (`[tool.ruff]` and `[tool.black]`). Line length is 120 characters.
 
 - **Testing**: Always include tests for new code or changes. We aim for industry-standard levels of test coverage.
 

--- a/bsv/overlay_tools/lookup_resolver.py
+++ b/bsv/overlay_tools/lookup_resolver.py
@@ -165,30 +165,48 @@ class HTTPSOverlayLookupFacilitator:
             raise LookupError(f"Lookup failed: {e!s}")
 
     def _parse_binary_response(self, data: bytes) -> LookupAnswer:
-        """Parse binary response format."""
+        """Parse the binary (``application/octet-stream``) output-list format.
+
+        Wire format (matching the TypeScript SDK's ``LookupResolver``)::
+
+            varint(nOutpoints)
+            per outpoint:  txid (32 bytes) | varint(outputIndex)
+                           | varint(contextLength) | context (contextLength bytes)
+            trailing:      one combined BEEF holding every referenced transaction
+
+        Each output's BEEF is reconstructed from the trailing combined BEEF,
+        selecting the subject transaction by txid.
+        """
+        from bsv.transaction import Transaction
+        from bsv.transaction.beef import parse_beef
         from bsv.utils import Reader
 
         reader = Reader(data)
-        n_outpoints = reader.read_var_int()
+        n_outpoints = reader.read_var_int_num()
+
+        outpoints = []
+        for _ in range(n_outpoints):
+            txid = reader.read(32).hex()
+            output_index = reader.read_var_int_num()
+            context_length = reader.read_var_int_num()
+            context = reader.read(context_length) if context_length > 0 else None
+            outpoints.append((txid, output_index, context))
+
+        trailing = bytes(reader.read() or b"")  # one combined BEEF for every referenced tx
+        beef_set = parse_beef(trailing) if trailing else None
 
         outputs = []
-        for _ in range(n_outpoints):
-            reader.read(32).hex()  # txid (not used in simplified implementation)
-            output_index = reader.read_var_int()
-            context_length = reader.read_var_int()
-
-            context = None
-            if context_length > 0:
-                context = reader.read(context_length)
-
-            # For now, we'll store the txid and reconstruct BEEF later
-            # This is a simplified implementation
-            outputs.append(
-                LookupOutput(beef=b"", output_index=output_index, context=context)  # Would need full transaction data
-            )
-
-        reader.read()  # beef (not used in simplified implementation)
-        # In a full implementation, we'd reconstruct the BEEF transactions here
+        for txid, output_index, context in outpoints:
+            beef = b""
+            if beef_set is not None:
+                btx = beef_set.find_transaction(txid)
+                if btx is not None:
+                    # parse_beef populates tx_obj for V2 and tx_bytes for V1;
+                    # fall back to the raw bytes when the object is absent.
+                    tx = btx.tx_obj or (Transaction.from_hex(btx.tx_bytes.hex()) if btx.tx_bytes else None)
+                    if tx is not None:
+                        beef = tx.to_beef()
+            outputs.append(LookupOutput(beef=beef, output_index=output_index, context=context))
 
         return LookupAnswer(type="output-list", outputs=outputs)
 

--- a/bsv/overlay_tools/lookup_resolver.py
+++ b/bsv/overlay_tools/lookup_resolver.py
@@ -152,8 +152,8 @@ class HTTPSOverlayLookupFacilitator:
                         return self._parse_binary_response(data)
                     else:
                         # JSON response format
-                        await response.json()
-                        return LookupAnswer(type="custom", outputs=[])  # Custom responses don't have outputs
+                        json_data = await response.json()
+                        return self._parse_json_response(json_data)
 
         try:
             return await _perform_lookup()
@@ -163,6 +163,67 @@ class HTTPSOverlayLookupFacilitator:
             raise
         except Exception as e:
             raise LookupError(f"Lookup failed: {e!s}")
+
+    @staticmethod
+    def _coerce_bytes(val) -> bytes:
+        """Coerce a JSON beef/context value to ``bytes``.
+
+        Accepts:
+        - ``list[int]``  — TS overlay-express wire format (``number[]``)
+        - base64 ``str`` — Go overlay-services wire format (``[]byte`` → JSON)
+        - hex ``str``    — alternate string encoding
+        - ``bytes``      — pass-through
+        - ``None``       → ``b""``
+        """
+        if val is None:
+            return b""
+        if isinstance(val, (bytes, bytearray)):
+            return bytes(val)
+        if isinstance(val, list):
+            return bytes(val)
+        if isinstance(val, str):
+            try:
+                return bytes.fromhex(val)
+            except ValueError:
+                import base64
+
+                return base64.b64decode(val)
+        return b""
+
+    @staticmethod
+    def _parse_json_response(json_data) -> LookupAnswer:
+        """Parse a JSON lookup response.
+
+        Wire shape::
+
+            {"type": "output-list",
+             "outputs": [{"beef": ..., "outputIndex": N, "context?": ...}, ...]}
+
+        ``beef`` encoding varies by server implementation:
+        - TS overlay-express: ``number[]`` (e.g. ``[222, 173, 190, 239]``)
+        - Go overlay-services: base64 string (e.g. ``"3q2+7w=="``)
+        - Other: hex string possible
+
+        A non-output-list ``type`` (e.g. ``"freeform"``) is passed through
+        with an empty output list.
+        """
+        if not isinstance(json_data, dict):
+            return LookupAnswer(type="custom", outputs=[])
+
+        answer_type = json_data.get("type", "output-list")
+
+        if answer_type == "output-list":
+            raw_outputs = json_data.get("outputs") or []
+            outputs = []
+            for raw in raw_outputs:
+                beef_val = HTTPSOverlayLookupFacilitator._coerce_bytes(raw.get("beef"))
+                output_index = int(raw.get("outputIndex", 0))
+                context_val = raw.get("context")
+                context = HTTPSOverlayLookupFacilitator._coerce_bytes(context_val) if context_val is not None else None
+                outputs.append(LookupOutput(beef=beef_val, output_index=output_index, context=context))
+            return LookupAnswer(type="output-list", outputs=outputs)
+
+        return LookupAnswer(type=answer_type, outputs=[])
 
     def _parse_binary_response(self, data: bytes) -> LookupAnswer:
         """Parse the binary (``application/octet-stream``) output-list format.

--- a/tests/bsv/overlay/test_parse_binary_response_golden.py
+++ b/tests/bsv/overlay/test_parse_binary_response_golden.py
@@ -1,0 +1,126 @@
+"""Golden tests for HTTPSOverlayLookupFacilitator._parse_binary_response.
+
+These pin the binary (``application/octet-stream``) lookup-response format
+to the reference TypeScript SDK (``@bsv/sdk`` LookupResolver), which reads::
+
+    varint(nOutpoints)
+    per outpoint:  txid (32 bytes) | varint(outputIndex)
+                   | varint(contextLength) | context (contextLength bytes)
+    trailing:      one combined BEEF holding every referenced transaction
+
+and reconstructs each output's BEEF via ``Transaction.fromBEEF(beef, txid)``.
+
+The Python implementation must do the same: stop crashing on the varint reads
+and populate each output's ``beef`` from the trailing combined BEEF, selecting
+the subject transaction by txid. The trailing BEEF is a plain combined BEEF and
+is exercised here in both V1 and V2 encodings.
+"""
+
+import pytest
+
+from bsv.keys import PrivateKey
+from bsv.overlay_tools.lookup_resolver import HTTPSOverlayLookupFacilitator
+from bsv.script.type import P2PKH
+from bsv.transaction import Transaction
+from bsv.transaction.beef import BEEF_V2, parse_beef
+from bsv.transaction_output import TransactionOutput
+from bsv.utils import Writer
+
+
+def _tx_with_outputs(n: int = 1) -> Transaction:
+    addr = PrivateKey().address()
+    outputs = [TransactionOutput(locking_script=P2PKH().lock(addr), satoshis=1000 - i) for i in range(n)]
+    return Transaction([], outputs)
+
+
+def _as_v2(beef_v1: bytes) -> bytes:
+    """Re-encode a V1 BEEF blob as V2 (same transactions, newer container)."""
+    beef = parse_beef(beef_v1)
+    beef.version = BEEF_V2
+    return beef.to_binary()
+
+
+def _build_binary_response(outpoints, trailing_beef: bytes) -> bytes:
+    """Serialize the octet-stream lookup response the reference SDK emits.
+
+    ``outpoints`` is a list of ``(txid_hex, output_index, context_bytes_or_none)``.
+    """
+    writer = Writer()
+    writer.write_var_int_num(len(outpoints))
+    for txid_hex, output_index, context in outpoints:
+        writer.write(bytes.fromhex(txid_hex))  # 32 bytes, display order
+        writer.write_var_int_num(output_index)
+        context = context or b""
+        writer.write_var_int_num(len(context))
+        if context:
+            writer.write(context)
+    writer.write(trailing_beef)
+    return writer.to_bytes()
+
+
+def _assert_output_carries(output, expected_txid: str):
+    """Each output's beef must be a real BEEF holding the expected subject tx."""
+    assert output.beef, "output.beef must not be empty (BEEF was dropped)"
+    recovered = parse_beef(bytes(output.beef))
+    assert recovered.find_transaction(expected_txid) is not None
+
+
+@pytest.mark.parametrize("encode", [lambda b: b, _as_v2], ids=["beef_v1", "beef_v2"])
+def test_single_output_roundtrip(encode):
+    tx = _tx_with_outputs(1)
+    txid = tx.txid()
+    trailing = encode(tx.to_beef())
+    data = _build_binary_response([(txid, 0, None)], trailing)
+
+    answer = HTTPSOverlayLookupFacilitator()._parse_binary_response(data)
+
+    assert answer.type == "output-list"
+    assert len(answer.outputs) == 1
+    out = answer.outputs[0]
+    assert out.output_index == 0
+    assert out.context is None
+    _assert_output_carries(out, txid)
+
+
+@pytest.mark.parametrize("encode", [lambda b: b, _as_v2], ids=["beef_v1", "beef_v2"])
+def test_context_is_preserved(encode):
+    tx = _tx_with_outputs(1)
+    txid = tx.txid()
+    trailing = encode(tx.to_beef())
+    context = b"\xde\xad\xbe\xef context bytes"
+    data = _build_binary_response([(txid, 0, context)], trailing)
+
+    answer = HTTPSOverlayLookupFacilitator()._parse_binary_response(data)
+
+    assert len(answer.outputs) == 1
+    assert bytes(answer.outputs[0].context) == context
+    _assert_output_carries(answer.outputs[0], txid)
+
+
+def test_multiple_outputs_same_tx():
+    # Two outpoints of the same transaction (different vouts), one trailing BEEF.
+    tx = _tx_with_outputs(2)
+    txid = tx.txid()
+    trailing = tx.to_beef()
+    data = _build_binary_response(
+        [(txid, 0, None), (txid, 1, b"ctx-1")],
+        trailing,
+    )
+
+    answer = HTTPSOverlayLookupFacilitator()._parse_binary_response(data)
+
+    assert len(answer.outputs) == 2
+    assert [o.output_index for o in answer.outputs] == [0, 1]
+    assert answer.outputs[0].context is None
+    assert bytes(answer.outputs[1].context) == b"ctx-1"
+    for out in answer.outputs:
+        _assert_output_carries(out, txid)
+
+
+def test_empty_output_list():
+    # nOutpoints = 0, no trailing BEEF — must not crash and yields no outputs.
+    writer = Writer()
+    writer.write_var_int_num(0)
+    answer = HTTPSOverlayLookupFacilitator()._parse_binary_response(writer.to_bytes())
+    assert answer.type == "output-list"
+    assert answer.outputs == []

--- a/tests/bsv/overlay_tools/test_lookup_resolver.py
+++ b/tests/bsv/overlay_tools/test_lookup_resolver.py
@@ -143,3 +143,98 @@ class TestLookupResolver:
         config = LookupResolverConfig(additional_hosts=additional)
         resolver = LookupResolver(config)
         assert resolver.additional_hosts == additional
+
+
+class TestParseJsonResponse:
+    """Tests for HTTPSOverlayLookupFacilitator._parse_json_response."""
+
+    def test_output_list_with_hex_beef(self):
+        json_data = {
+            "type": "output-list",
+            "outputs": [
+                {"beef": "deadbeef", "outputIndex": 0},
+                {"beef": "cafebabe", "outputIndex": 2},
+            ],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.type == "output-list"
+        assert len(answer.outputs) == 2
+        assert answer.outputs[0].beef == bytes.fromhex("deadbeef")
+        assert answer.outputs[0].output_index == 0
+        assert answer.outputs[1].beef == bytes.fromhex("cafebabe")
+        assert answer.outputs[1].output_index == 2
+
+    def test_output_list_with_number_array_beef(self):
+        """TS overlay-express sends beef as number[] (byte array) over JSON."""
+        json_data = {
+            "type": "output-list",
+            "outputs": [
+                {"beef": [0xDE, 0xAD, 0xBE, 0xEF], "outputIndex": 0},
+            ],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.outputs[0].beef == b"\xde\xad\xbe\xef"
+        assert answer.outputs[0].output_index == 0
+
+    def test_output_list_with_base64_beef(self):
+        """Go overlay-services sends beef as base64 string (Go []byte JSON default)."""
+        import base64
+
+        raw = b"\xde\xad\xbe\xef"
+        b64 = base64.b64encode(raw).decode()  # "3q2+7w=="
+        json_data = {
+            "type": "output-list",
+            "outputs": [{"beef": b64, "outputIndex": 0}],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.outputs[0].beef == raw
+
+    def test_output_list_with_context(self):
+        json_data = {
+            "type": "output-list",
+            "outputs": [
+                {"beef": "aa", "outputIndex": 0, "context": [1, 2, 3]},
+            ],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.outputs[0].context == bytes([1, 2, 3])
+
+    def test_output_list_without_context_is_none(self):
+        json_data = {
+            "type": "output-list",
+            "outputs": [{"beef": "aa", "outputIndex": 0}],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.outputs[0].context is None
+
+    def test_output_list_implicit_type(self):
+        json_data = {
+            "outputs": [{"beef": "aa", "outputIndex": 1}],
+        }
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.type == "output-list"
+        assert len(answer.outputs) == 1
+        assert answer.outputs[0].output_index == 1
+
+    def test_output_list_empty_outputs(self):
+        json_data = {"type": "output-list", "outputs": []}
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.type == "output-list"
+        assert answer.outputs == []
+
+    def test_freeform_type_returns_no_outputs(self):
+        json_data = {"type": "freeform", "result": "some custom data"}
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.type == "freeform"
+        assert answer.outputs == []
+
+    def test_non_dict_returns_custom(self):
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response([1, 2, 3])
+        assert answer.type == "custom"
+        assert answer.outputs == []
+
+    def test_missing_outputs_key(self):
+        json_data = {"type": "output-list"}
+        answer = HTTPSOverlayLookupFacilitator._parse_json_response(json_data)
+        assert answer.type == "output-list"
+        assert answer.outputs == []


### PR DESCRIPTION
## Description of Changes

Fix two bugs in `LookupResolver` and add linting documentation for contributors.

**LookupResolver JSON response path fix:**
The JSON response path in `HTTPSOverlayLookupFacilitator.lookup()` was calling `response.json()` but discarding the result, always returning an empty `LookupAnswer`. This meant any overlay host returning JSON (rather than binary) would produce no outputs.

Added `_parse_json_response()` and `_coerce_bytes()` to properly handle the output-list JSON format. The `beef` field encoding differs across server implementations:
- **TS overlay-express**: `number[]` (JS byte array, e.g. `[222, 173, 190, 239]`)
- **Go overlay-services**: base64 string (Go `[]byte` JSON default, e.g. `"3q2+7w=="`)
- hex string is also accepted as a fallback

Note: the binary path (`application/octet-stream`) is triggered by the `X-Aggregation: yes` header, which this SDK always sends. The Go overlay server does not implement the binary path and always returns JSON. The TS overlay server supports both, selecting based on `X-Aggregation`.

**Binary response parser fix (PR #162):**
Replaced `read_var_int()` with `read_var_int_num()` in `_parse_binary_response()` and added per-output BEEF reconstruction from the trailing combined BEEF.

**Linting documentation:**
Added Ruff/Black instructions to `CLAUDE.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md` so that external contributors and AI tools know to run linters before submitting.

## Linked Issues / Tickets

Related to PR #162 (read_var_int → read_var_int_num)

## Testing Procedure

- [x] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

`TestParseJsonResponse` — 10 test cases covering:
- `number[]` beef (TS overlay-express format)
- base64 beef (Go overlay-services format)
- hex string beef
- `context` field present / absent
- implicit `type` (defaults to `output-list`)
- empty outputs
- `freeform` type
- non-dict input
- missing `outputs` key

```
pytest tests/bsv/overlay_tools/test_lookup_resolver.py -v  # 25 passed
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have updated `CHANGELOG.md` with my changes
- [x] I have run the linter and formatter (`ruff check . && black --check .` — both pass with no errors)
