### PR TITLE
docs: add CHANGELOG for v2.2.0 and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [2.2.0 - 2026-06-10](#220---2026-06-10)
 - [2.1.5 - 2026-06-05](#215---2026-06-05)
 - [2.1.4 - 2026-05-27](#214---2026-05-27)
 - [2.1.2 - 2026-05-20](#212---2026-05-20)
@@ -29,6 +30,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [2.2.0] - 2026-06-10
+
+### Changed
+
+- **Breaking:** Removed `WalletInterface` inheritance from `ProtoWallet` — now a standalone class with only cryptographic operations, aligning with TS/Go SDK architecture.
+- Added `DeprecationWarning` to 21 non-crypto `ProtoWallet` methods (`create_action`, `sign_action`, `internalize_action`, `list_actions`, `list_outputs`, `list_certificates`, etc.). Use `Wallet` from `py-wallet-toolbox` instead.
+- `IdentityClient` and `ContactsManager` no longer silently create a dummy `ProtoWallet` when no wallet is provided — they now raise `ValueError("wallet is required")`.
+
+### Fixed
+
+- Replaced local dummy `WalletInterface` class in `verifiable_certificate.py` with proper import from `bsv.wallet.wallet_interface`.
 
 ---
 

--- a/bsv/__init__.py
+++ b/bsv/__init__.py
@@ -55,4 +55,4 @@ from .transaction_preimage import *
 # Step 6.8: utils
 from .utils import *
 
-__version__ = "2.1.2"
+__version__ = "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bsv-sdk"
-version = "2.1.3"
+version = "2.2.0"
 description = "BSV BLOCKCHAIN | Software Development Kit for Python"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for v2.2.0 (ProtoWallet deprecation changes from PR #164)
- Bump version to 2.2.0 in `pyproject.toml` and `bsv/__init__.py`
- Fix version drift: pyproject.toml was 2.1.3, __init__.py was 2.1.2 — now both 2.2.0

## Context

PR #164 merged the breaking ProtoWallet changes but did not include a CHANGELOG entry or version bump. This is a docs-only follow-up.

## Test plan

- [ ] CI passes (no code changes)