### PR TITLE
docs: bump version to v2.2.1 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [2.2.1 - 2026-06-12](#221---2026-06-12)
 - [2.2.0 - 2026-06-10](#220---2026-06-10)
 - [2.1.5 - 2026-06-05](#215---2026-06-05)
 - [2.1.4 - 2026-05-27](#214---2026-05-27)
@@ -30,6 +31,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [2.2.1] - 2026-06-12
+
+### Fixed
+
+- Fixed strict DER encoding in `_sign_custom_k()` — R and S values are now encoded with minimal byte length per DER rules, fixing intermittent `ValueError: The DER-encoded signature could not be parsed` in R-puzzle signing.
+- Fixed Black formatting violations in `wallet_impl.py` (long `warnings.warn()` lines, unnecessary `pass` statement).
+- Fixed Ruff I001 import sorting in `verifiable_certificate.py`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.2.1] - 2026-06-12
 
-### Fixed
+Re-release of v2.2.0 for PyPI — the original v2.2.0 package was published before #166 was merged, so PyPI's v2.2.0 is missing the fixes below. This release includes no additional code changes beyond v2.2.0 (tag `adaa031`).
+
+### Fixed (included since PyPI v2.2.0)
 
 - Fixed strict DER encoding in `_sign_custom_k()` — R and S values are now encoded with minimal byte length per DER rules, fixing intermittent `ValueError: The DER-encoded signature could not be parsed` in R-puzzle signing.
-- Fixed Black formatting violations in `wallet_impl.py` (long `warnings.warn()` lines, unnecessary `pass` statement).
-- Fixed Ruff I001 import sorting in `verifiable_certificate.py`.
+- Fixed Black/Ruff lint violations in `wallet_impl.py` and `verifiable_certificate.py`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bsv-sdk"
-version = "2.2.0"
+version = "2.2.1"
 description = "BSV BLOCKCHAIN | Software Development Kit for Python"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version from 2.2.0 to 2.2.1 in `pyproject.toml`
- Add v2.2.1 CHANGELOG entry documenting the DER encoding fix and lint fixes from #166

v2.2.0 was already published to PyPI before #166 was merged, so a patch release is needed to publish the corrected package.

## Test plan
- [ ] CI passes on all Python versions
- [ ] Version in `pyproject.toml` is `2.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)