### PR TITLE
ci: make coverage badge push non-fatal on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,9 @@ jobs:
 
     - name: Commit and push updated coverage badge (push to master only)
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
+      # Branch protection blocks direct pushes to master, so this push may be rejected.
+      # Treat that as non-fatal: the badge update is best-effort and must not fail the build.
+      continue-on-error: true
       run: |
         # Only proceed if README.md has changes
         if git diff --quiet README.md; then
@@ -77,7 +80,7 @@ jobs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add README.md
         git commit -m "chore: update coverage badge to ${{ steps.coverage.outputs.coverage }}% [skip ci]" || echo "No changes to commit."
-        git push
+        git push || echo "::warning::Coverage badge push rejected (branch protection); skipping badge update."
 
     - name: Upload coverage reports
       if: matrix.python-version == '3.11'


### PR DESCRIPTION
## Summary
The `build` workflow fails on **every** push to `master` — not because of tests, but because the "Commit and push updated coverage badge" step tries to `git push` directly to `master`, which branch protection rejects (`GH013: Changes must be made through a pull request`).

This step is skipped on PRs (the `if` guard requires `github.ref == 'refs/heads/master'`), which is why PR builds are green but the post-merge master build goes red.

## Fix
- Mark the badge-push step `continue-on-error: true` — it is best-effort and must not fail the build.
- Downgrade a rejected `git push` to a `::warning::` instead of a hard error.

Tests, lint, and packaging are unaffected; only the cosmetic badge auto-commit is made non-fatal.

## Test plan
- [ ] PR build stays green (step is skipped on PRs anyway)
- [ ] Next push to master no longer fails on the badge step

🤖 Generated with [Claude Code](https://claude.com/claude-code)