### PR TITLE
feat: ARC broadcaster format selection (json/raw/beef)

### DIFF
--- a/bsv/broadcasters/arc.py
+++ b/bsv/broadcasters/arc.py
@@ -24,6 +24,7 @@ class ARCConfig:
         callback_url: Optional[str] = None,
         callback_token: Optional[str] = None,
         headers: Optional[dict[str, str]] = None,
+        format: Optional[str] = None,
     ):
         self.api_key = api_key
         self.http_client = http_client
@@ -32,6 +33,7 @@ class ARCConfig:
         self.callback_url = callback_url
         self.callback_token = callback_token
         self.headers = headers
+        self.format = format
 
 
 def default_deployment_id() -> str:
@@ -156,6 +158,7 @@ class ARC(Broadcaster):
             self.callback_url = None
             self.callback_token = None
             self.headers = None
+            self.format = "json"
         else:
             config = config or ARCConfig()
             self.api_key = config.api_key
@@ -165,6 +168,7 @@ class ARC(Broadcaster):
             self.callback_url = config.callback_url
             self.callback_token = config.callback_token
             self.headers = config.headers
+            self.format = config.format or "json"
 
     async def broadcast(self, tx: "Transaction") -> BroadcastResponse | BroadcastFailure:
         """Broadcast a transaction to the BSV network via ARC.
@@ -174,13 +178,8 @@ class ARC(Broadcaster):
         mined or final. Use :meth:`check_transaction_status` and
         :meth:`categorize_transaction_status` to track confirmation progress.
         """
-        # Check if all inputs have source_transaction
         has_all_source_txs = all(input.source_transaction is not None for input in tx.inputs)
-        request_options = {
-            "method": "POST",
-            "headers": self.request_headers(),
-            "data": {"rawTx": tx.to_ef().hex() if has_all_source_txs else tx.hex()},
-        }
+        request_options = self._build_request_options(tx, has_all_source_txs)
         bound = self._http_timeout_for_v1_tx_post()
         if bound is not None:
             request_options["timeout"] = bound
@@ -238,9 +237,30 @@ class ARC(Broadcaster):
                 },
             )
 
-    def request_headers(self) -> dict[str, str]:
+    def _build_request_options(self, tx: "Transaction", has_all_source_txs: bool) -> dict:
+        if self.format == "beef":
+            content_type = "application/beef"
+            raw_data = tx.to_beef()
+        elif self.format == "raw":
+            content_type = "application/octet-stream"
+            raw_data = tx.to_ef() if has_all_source_txs else tx.serialize()
+        else:
+            content_type = "application/json"
+            raw_data = None
+
+        options: dict = {
+            "method": "POST",
+            "headers": self.request_headers(content_type=content_type),
+        }
+        if raw_data is not None:
+            options["raw_data"] = raw_data
+        else:
+            options["data"] = {"rawTx": tx.to_ef().hex() if has_all_source_txs else tx.hex()}
+        return options
+
+    def request_headers(self, content_type: str = "application/json") -> dict[str, str]:
         headers = {
-            "Content-Type": "application/json",
+            "Content-Type": content_type,
             "XDeployment-ID": self.deployment_id,
         }
 
@@ -303,7 +323,6 @@ class ARC(Broadcaster):
         :param timeout: Timeout setting in seconds
         :returns: BroadcastResponse or BroadcastFailure
         """
-        # Check if all inputs have source_transaction
         has_all_source_txs = all(input.source_transaction is not None for input in tx.inputs)
 
         effective_timeout = timeout
@@ -311,12 +330,13 @@ class ARC(Broadcaster):
         if bound is not None:
             effective_timeout = max(effective_timeout, bound)
 
+        request_options = self._build_request_options(tx, has_all_source_txs)
+        request_options["timeout"] = effective_timeout
+
         try:
-            response = self.sync_http_client.post(
+            response = self.sync_http_client.fetch(
                 f"{self.URL}/v1/tx",
-                data={"rawTx": tx.to_ef().hex() if has_all_source_txs else tx.hex()},
-                headers=self.request_headers(),
-                timeout=effective_timeout,
+                request_options,
             )
 
             response_json = response.json()

--- a/bsv/http_client.py
+++ b/bsv/http_client.py
@@ -32,12 +32,14 @@ class DefaultHttpClient(HttpClient):
         aiohttp_timeout = aiohttp.ClientTimeout(total=timeout_value) if timeout_value is not None else None
 
         async with aiohttp.ClientSession() as session:
+            raw_data = options.get("raw_data")
+            body_kwargs = {"data": raw_data} if raw_data is not None else {"json": options.get("data")}
             async with session.request(
                 method=options["method"],
                 url=url,
                 headers=options.get("headers", {}),
-                json=options.get("data"),
                 timeout=aiohttp_timeout,
+                **body_kwargs,
             ) as response:
                 text = await response.text()
                 ok = 200 <= response.status <= 299
@@ -93,8 +95,11 @@ class SyncHttpClient(HttpClient):
         timeout = options.get("timeout", self.default_timeout)
         data = options.get("data")
 
+        raw_data = options.get("raw_data")
         try:
-            if method.upper() in ["POST", "PUT", "PATCH"] and data is not None:
+            if raw_data is not None:
+                response = requests.request(method=method, url=url, headers=headers, data=raw_data, timeout=timeout)
+            elif method.upper() in ["POST", "PUT", "PATCH"] and data is not None:
                 response = requests.request(method=method, url=url, headers=headers, json=data, timeout=timeout)
             else:
                 response = requests.request(method=method, url=url, headers=headers, timeout=timeout)

--- a/tests/bsv/broadcasters/test_arc_broadcast_format.py
+++ b/tests/bsv/broadcasters/test_arc_broadcast_format.py
@@ -1,0 +1,278 @@
+"""Tests for ARC broadcaster format selection (json / raw / beef)."""
+
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bsv.broadcaster import BroadcastFailure, BroadcastResponse
+from bsv.broadcasters.arc import ARC, ARCConfig
+from bsv.http_client import HttpClient, HttpResponse, SyncHttpClient
+
+
+def _make_tx(has_source_txs: bool = True):
+    """Create a mock Transaction with controllable source_transaction presence."""
+    tx = MagicMock()
+    ef_bytes = b"\xef" * 32
+    mock_ef = MagicMock()
+    mock_ef.hex.return_value = ef_bytes.hex()
+    tx.to_ef.return_value = mock_ef
+    tx.hex.return_value = "aa" * 32
+    tx.serialize.return_value = b"\xaa" * 32
+    tx.to_beef.return_value = b"\xbe\xef" * 16
+
+    inp = MagicMock()
+    inp.source_transaction = MagicMock() if has_source_txs else None
+    tx.inputs = [inp]
+    return tx
+
+
+def _ok_response():
+    return HttpResponse(
+        ok=True,
+        status_code=200,
+        json_data={
+            "data": {
+                "txid": "abcd1234" * 8,
+                "txStatus": "SEEN_ON_NETWORK",
+            }
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# ARCConfig.format
+# ---------------------------------------------------------------------------
+
+
+class TestARCConfigFormat(unittest.TestCase):
+    def test_default_format_is_none(self):
+        cfg = ARCConfig()
+        assert cfg.format is None
+
+    def test_format_stored(self):
+        for fmt in ("json", "raw", "beef"):
+            cfg = ARCConfig(format=fmt)
+            assert cfg.format == fmt
+
+
+# ---------------------------------------------------------------------------
+# ARC.__init__ format resolution
+# ---------------------------------------------------------------------------
+
+
+class TestARCFormatInit(unittest.TestCase):
+    def test_str_config_defaults_to_json(self):
+        arc = ARC("https://arc.example.com", "my-api-key")
+        assert arc.format == "json"
+
+    def test_no_config_defaults_to_json(self):
+        arc = ARC("https://arc.example.com")
+        assert arc.format == "json"
+
+    def test_config_none_format_defaults_to_json(self):
+        arc = ARC("https://arc.example.com", ARCConfig())
+        assert arc.format == "json"
+
+    def test_config_format_propagated(self):
+        for fmt in ("json", "raw", "beef"):
+            arc = ARC("https://arc.example.com", ARCConfig(format=fmt))
+            assert arc.format == fmt
+
+
+# ---------------------------------------------------------------------------
+# async broadcast() – format variations
+# ---------------------------------------------------------------------------
+
+
+class TestBroadcastFormat(unittest.IsolatedAsyncioTestCase):
+    async def _broadcast_and_capture(self, fmt, has_source_txs=True):
+        mock_http = AsyncMock(HttpClient)
+        mock_http.fetch = AsyncMock(return_value=_ok_response())
+        cfg = ARCConfig(http_client=mock_http, format=fmt)
+        arc = ARC("https://arc.example.com", cfg)
+        tx = _make_tx(has_source_txs)
+        result = await arc.broadcast(tx)
+        call_args = mock_http.fetch.call_args
+        url = call_args[0][0]
+        options = call_args[0][1]
+        return result, url, options, tx
+
+    async def test_json_format_sends_json_body(self):
+        result, url, options, tx = await self._broadcast_and_capture("json")
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/json"
+        assert "data" in options
+        assert "rawTx" in options["data"]
+        assert "raw_data" not in options
+
+    async def test_json_format_is_default(self):
+        mock_http = AsyncMock(HttpClient)
+        mock_http.fetch = AsyncMock(return_value=_ok_response())
+        arc = ARC("https://arc.example.com", ARCConfig(http_client=mock_http))
+        tx = _make_tx()
+        await arc.broadcast(tx)
+        options = mock_http.fetch.call_args[0][1]
+        assert options["headers"]["Content-Type"] == "application/json"
+        assert "data" in options
+
+    async def test_raw_format_sends_binary_ef(self):
+        result, url, options, tx = await self._broadcast_and_capture("raw", has_source_txs=True)
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/octet-stream"
+        assert options["raw_data"] == tx.to_ef.return_value
+        assert "data" not in options
+        tx.to_ef.assert_called()
+
+    async def test_raw_format_without_source_txs_falls_back_to_serialize(self):
+        result, url, options, tx = await self._broadcast_and_capture("raw", has_source_txs=False)
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/octet-stream"
+        assert options["raw_data"] == tx.serialize.return_value
+        tx.serialize.assert_called()
+
+    async def test_beef_format_sends_binary_beef(self):
+        result, url, options, tx = await self._broadcast_and_capture("beef")
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/beef"
+        assert options["raw_data"] == tx.to_beef.return_value
+        assert "data" not in options
+        tx.to_beef.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# sync_broadcast() – format variations
+# ---------------------------------------------------------------------------
+
+
+class TestSyncBroadcastFormat(unittest.TestCase):
+    def _sync_broadcast_and_capture(self, fmt, has_source_txs=True):
+        mock_sync = MagicMock(SyncHttpClient)
+        mock_sync.fetch = MagicMock(return_value=_ok_response())
+        cfg = ARCConfig(sync_http_client=mock_sync, format=fmt)
+        arc = ARC("https://arc.example.com", cfg)
+        tx = _make_tx(has_source_txs)
+        result = arc.sync_broadcast(tx)
+        call_args = mock_sync.fetch.call_args
+        url = call_args[0][0]
+        options = call_args[0][1]
+        return result, url, options, tx
+
+    def test_json_format_sends_json_body(self):
+        result, url, options, tx = self._sync_broadcast_and_capture("json")
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/json"
+        assert "data" in options
+        assert "raw_data" not in options
+
+    def test_raw_format_sends_binary_ef(self):
+        result, url, options, tx = self._sync_broadcast_and_capture("raw", has_source_txs=True)
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/octet-stream"
+        assert options["raw_data"] == tx.to_ef.return_value
+
+    def test_raw_format_without_source_txs_falls_back_to_serialize(self):
+        result, url, options, tx = self._sync_broadcast_and_capture("raw", has_source_txs=False)
+        assert options["raw_data"] == tx.serialize.return_value
+
+    def test_beef_format_sends_binary_beef(self):
+        result, url, options, tx = self._sync_broadcast_and_capture("beef")
+        assert isinstance(result, BroadcastResponse)
+        assert options["headers"]["Content-Type"] == "application/beef"
+        assert options["raw_data"] == tx.to_beef.return_value
+
+    def test_sync_json_default_backward_compat(self):
+        mock_sync = MagicMock(SyncHttpClient)
+        mock_sync.fetch = MagicMock(return_value=_ok_response())
+        arc = ARC("https://arc.example.com", ARCConfig(sync_http_client=mock_sync))
+        tx = _make_tx()
+        arc.sync_broadcast(tx)
+        options = mock_sync.fetch.call_args[0][1]
+        assert options["headers"]["Content-Type"] == "application/json"
+        assert "rawTx" in options["data"]
+
+
+# ---------------------------------------------------------------------------
+# request_headers() content_type parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRequestHeadersContentType(unittest.TestCase):
+    def test_default_content_type(self):
+        arc = ARC("https://arc.example.com", ARCConfig(api_key="key"))
+        headers = arc.request_headers()
+        assert headers["Content-Type"] == "application/json"
+
+    def test_custom_content_type(self):
+        arc = ARC("https://arc.example.com", ARCConfig(api_key="key"))
+        headers = arc.request_headers(content_type="application/beef")
+        assert headers["Content-Type"] == "application/beef"
+
+    def test_api_key_in_headers(self):
+        arc = ARC("https://arc.example.com", ARCConfig(api_key="my-key", format="beef"))
+        headers = arc.request_headers(content_type="application/beef")
+        assert headers["Authorization"] == "Bearer my-key"
+        assert headers["Content-Type"] == "application/beef"
+
+
+# ---------------------------------------------------------------------------
+# http_client.py raw_data support (unit-level)
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientRawData(unittest.TestCase):
+    def test_sync_fetch_raw_data_uses_data_kwarg(self):
+        """SyncHttpClient.fetch sends raw bytes via data= when raw_data is present."""
+        import unittest.mock as um
+
+        from bsv.http_client import SyncHttpClient
+
+        client = SyncHttpClient()
+        payload = b"\xbe\xef" * 8
+        options = {
+            "method": "POST",
+            "headers": {"Content-Type": "application/beef"},
+            "raw_data": payload,
+        }
+
+        with um.patch("bsv.http_client.requests.request") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": {"txid": "abc"}}
+            mock_req.return_value = mock_resp
+
+            client.fetch("https://example.com/v1/tx", options)
+
+            mock_req.assert_called_once()
+            _, kwargs = mock_req.call_args
+            assert kwargs["data"] == payload
+            assert "json" not in kwargs
+
+    def test_sync_fetch_json_data_unchanged(self):
+        """SyncHttpClient.fetch still sends JSON when raw_data is absent."""
+        import unittest.mock as um
+
+        from bsv.http_client import SyncHttpClient
+
+        client = SyncHttpClient()
+        options = {
+            "method": "POST",
+            "headers": {"Content-Type": "application/json"},
+            "data": {"rawTx": "aabb"},
+        }
+
+        with um.patch("bsv.http_client.requests.request") as mock_req:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"data": {"txid": "abc"}}
+            mock_req.return_value = mock_resp
+
+            client.fetch("https://example.com/v1/tx", options)
+
+            _, kwargs = mock_req.call_args
+            assert kwargs["json"] == {"rawTx": "aabb"}
+            assert "data" not in kwargs or kwargs.get("data") is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bsv/broadcasters/test_broadcaster_arc.py
+++ b/tests/bsv/broadcasters/test_broadcaster_arc.py
@@ -136,7 +136,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
             },
         )
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(return_value=mock_response)
+        mock_sync_http_client.fetch = MagicMock(return_value=mock_response)
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)
@@ -158,7 +158,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
             },
         )
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(return_value=mock_response)  # fetch → post
+        mock_sync_http_client.fetch = MagicMock(return_value=mock_response)  # fetch → post
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)
@@ -178,7 +178,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
             json_data={"data": {"status": "ERR_BAD_REQUEST", "detail": "Invalid transaction"}},
         )
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(return_value=mock_response)  # fetch → post
+        mock_sync_http_client.fetch = MagicMock(return_value=mock_response)  # fetch → post
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)
@@ -194,7 +194,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
             ok=False, status_code=408, json_data={"data": {"status": "ERR_TIMEOUT", "detail": "Request timed out"}}
         )
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(return_value=mock_response)
+        mock_sync_http_client.fetch = MagicMock(return_value=mock_response)
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)
@@ -211,7 +211,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
             ok=False, status_code=503, json_data={"data": {"status": "ERR_CONNECTION", "detail": "Service unavailable"}}
         )
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(return_value=mock_response)
+        mock_sync_http_client.fetch = MagicMock(return_value=mock_response)
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)
@@ -224,7 +224,7 @@ class TestARCBroadcast(unittest.IsolatedAsyncioTestCase):
 
     def test_sync_broadcast_exception(self):
         mock_sync_http_client = MagicMock(SyncHttpClient)
-        mock_sync_http_client.post = MagicMock(side_effect=Exception("Internal Error"))
+        mock_sync_http_client.fetch = MagicMock(side_effect=Exception("Internal Error"))
 
         arc_config = ARCConfig(api_key=self.api_key, sync_http_client=mock_sync_http_client)
         arc = ARC(self.URL, arc_config)


### PR DESCRIPTION
## Summary
- ARC broadcaster に送信フォーマット選択機能を追加。`ARCConfig(format=...)` で `"json"` (デフォルト), `"raw"` (`application/octet-stream` + EF/serialize バイナリ), `"beef"` (`application/beef` + BEEF バイナリ) を選択可能に
- `DefaultHttpClient.fetch()` / `SyncHttpClient.fetch()` に `raw_data` (bytes) バイナリ送信パスを追加
- `format` 未指定時は既存の JSON + hex 動作を完全に維持（後方互換）

## Changes
- `bsv/http_client.py` — `options["raw_data"]` がある場合 `data=bytes` でバイナリ送信、なければ従来の `json=dict` パス
- `bsv/broadcasters/arc.py` — `ARCConfig.format`, `ARC._build_request_options()`, `request_headers(content_type=)` 追加。`sync_broadcast()` を `fetch()` 直接呼び出しに統一
- `tests/bsv/broadcasters/test_arc_broadcast_format.py` — 新規テスト 21 件

## Test plan
- [x] 既存 broadcaster テスト全 117 件パス
- [x] 新規フォーマットテスト 21 件パス（json/raw/beef × async/sync、Content-Type 検証、http_client raw_data 単体）
- [x] ruff + black クリーン
- [x] ライブ ARC エンドポイントで raw/beef 送信を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)