### PR TITLE
fix(build): PEP 639 license format + twine check diagnostic

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -175,6 +175,8 @@ jobs:
       - name: Check distributions
         run: |
           pip install twine
+          twine --version
+          ls -la dist/
           twine check dist/*
 
       - name: Publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.3.0"
 description = "BSV BLOCKCHAIN | Software Development Kit for Python"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "LicenseRef-Open-BSV-4"
 authors = [
     { name = "Aaron", email = "aaron@scrypt.io" },
 ]


### PR DESCRIPTION
Description of Changes
The v2.3.0 tag push triggered wheels.yml, but the Publish to PyPI job failed at the twine check step, so the package was never published to PyPI.

Root cause: license = {text = "MIT"} (legacy table form) in pyproject.toml generates an unrecognized license-file metadata field with newer setuptools/twine:


InvalidDistribution: unrecognized or malformed field 'license-file'
Additionally, the license name itself was wrong — this project uses the Open BSV License v4, not MIT.

Changes:

license = {text = "MIT"} → license = "LicenseRef-Open-BSV-4" (PEP 639 compliant + correct license)
Added twine --version and ls -la dist/ diagnostic output to the twine check step
Linked Issues / Tickets
Fixes the v2.3.0 PyPI publish failure. After merge, the v2.3.0 tag will be moved and re-pushed to re-trigger the publish workflow.

Testing Procedure
Built sdist + wheel locally and confirmed twine check passes.

 I have added new unit tests
 All tests pass locally
 I have tested manually in my local environment
Checklist:
 I have performed a self-review of my own code
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 I have updated CHANGELOG.md with my changes
 I have run the linter and formatter (ruff check . && black --check . — both must pass with no errors)