### PR TITLE
fix(ci): upgrade packaging in twine check for PEP 639 metadata

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -174,8 +174,12 @@ jobs:
 
       - name: Check distributions
         run: |
-          pip install twine
+          # packaging>=24.2 is required to validate PEP 639 metadata
+          # (License-Expression / License-File, Metadata-Version 2.4) that
+          # setuptools>=77 emits; the runner's system packaging is too old.
+          pip install --upgrade twine packaging
           twine --version
+          python -c "import packaging; print('packaging', packaging.__version__)"
           ls -la dist/
           twine check dist/*
 


### PR DESCRIPTION
## Summary
The v2.3.1 tag publish failed at the `twine check` step:

```
InvalidDistribution: Invalid distribution metadata: unrecognized or
malformed field 'license-expression'; unrecognized or malformed field
'license-file'
```

The runner's system `packaging` (24.0) predates PEP 639 metadata support (License-Expression / License-File, Metadata-Version 2.4), which `setuptools>=77` now emits. `twine` delegates metadata validation to `packaging`, so the check fails even though the wheels are valid.

## Fix
`pip install --upgrade twine packaging` in the Check distributions step, with a version echo for future diagnostics.

## After merge
The v2.3.1 tag must be recreated on the merged commit so the tag-triggered workflow picks up this fix (the workflow definition is read from the tag's commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)