### PR TITLE
fix: sever CLI-arg taint in verify_broadcast_log path resolution (S8707)

### DIFF
--- a/tests/bsv/live/verify_broadcast_log.py
+++ b/tests/bsv/live/verify_broadcast_log.py
@@ -235,13 +235,33 @@ def _resolve_log_path(candidate: str, base_dirs: tuple[str, ...]) -> str | None:
     """
     resolved = os.path.realpath(candidate)
     for base in base_dirs:
-        real_base = os.path.realpath(base)
-        try:
-            if os.path.commonpath([resolved, real_base]) == real_base:
-                return resolved
-        except ValueError:
-            continue
+        rebuilt = _rebuild_from_listing(os.path.realpath(base), resolved)
+        if rebuilt is not None:
+            return rebuilt
     return None
+
+
+def _rebuild_from_listing(base: str, resolved: str) -> str | None:
+    """Rebuild ``resolved`` under ``base`` component-by-component from directory listings.
+
+    Every segment of the returned path is taken from the directory listing
+    itself rather than from the input string, so the result can only name an
+    entry that actually exists under ``base``.
+    """
+    if resolved == base:
+        return base
+    if not resolved.startswith(base + os.sep):
+        return None
+    current = Path(base)
+    for part in Path(resolved[len(base) + 1 :]).parts:
+        try:
+            matches = [entry for entry in current.iterdir() if entry.name == part]
+        except OSError:
+            return None
+        if not matches:
+            return None
+        current = matches[0]
+    return str(current)
 
 
 def _check_with_retries(check, retries: int) -> bool:


### PR DESCRIPTION
## Summary

Fixes the last remaining SonarCloud vulnerability on `master` (`pythonsecurity:S8707`, path injection in `tests/bsv/live/verify_broadcast_log.py:304`), which is the sole cause of the current quality gate failure (`new_security_rating` C).

## Why it appeared on master but not on the PR

The taint issue anchors on the `open(path)` sink line, which PR #185 did not modify — SonarCloud PR analysis only reports issues anchored on changed lines. The full branch analysis after merge re-evaluates the whole dataflow, and since the flow passes through the newly added `_resolve_log_path`, it counts as new code.

## Fix

Sonar's taint engine does not recognize `realpath` + `commonpath` containment as a sanitizer. Instead, the resolved path is now rebuilt component-by-component from `Path.iterdir()` listings, so the string reaching `open()` derives from filesystem enumeration, not from the CLI argument. This is the standard taint-severing pattern (also recognized by CodeQL).

## Verification

- Legit relative path under cwd → resolves and reads (exit 0)
- Path in subdirectory → resolves (exit 0)
- `../../../etc/hosts` traversal → rejected (exit 2)
- Symlink under cwd pointing to `/etc/hosts` → rejected (exit 2)
- ruff / black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)