### PR TITLE
fix: harden native tx_preimage against missing non-signing scripts/amounts (#187)

### DIFF
--- a/bsv/transaction.py
+++ b/bsv/transaction.py
@@ -20,7 +20,7 @@ from .script.script import Script
 from .script.type import P2PKH
 from .transaction_input import TransactionInput
 from .transaction_output import TransactionOutput
-from .transaction_preimage import tx_preimage
+from .transaction_preimage import _outputs_to_bytes_for_input, tx_preimage
 from .utils import Reader, Writer, reverse_hex_byte_order, unsigned_to_varint
 
 try:
@@ -171,7 +171,13 @@ class Transaction:
         for i, inp in enumerate(self.inputs):
             sh = hash_type if i == input_index else int(inp.sighash)
             sats = prev_satoshis if (prev_satoshis != 0 and i == input_index) else (inp.satoshis or 0)
-            script = inp.locking_script.serialize() if inp.locking_script else b""
+            # The signing input's scriptCode enters the digest, so it must be present
+            # (parity with the pure-Python _build_bip143_preimage). A non-signing input's
+            # script never enters this digest, so a missing one is replaced with b"".
+            if i == input_index or inp.locking_script:
+                script = inp.locking_script.serialize()
+            else:
+                script = b""
             input_tuples.append(
                 (
                     inp.source_txid,
@@ -182,7 +188,7 @@ class Transaction:
                     sh,
                 )
             )
-        output_bytes = [out.serialize() for out in self.outputs]
+        output_bytes = _outputs_to_bytes_for_input(self.outputs, input_index, hash_type)
         preimages = _bsv_native.tx_preimages(self.version, self.locktime, input_tuples, output_bytes)
         return preimages[input_index]
 

--- a/bsv/transaction_preimage.py
+++ b/bsv/transaction_preimage.py
@@ -61,22 +61,90 @@ def _preimage(
     return stream.getvalue()
 
 
+def _input_to_tuple(inp: TransactionInput, script: bytes) -> tuple:
+    return (
+        inp.source_txid,
+        inp.source_output_index,
+        script,
+        inp.satoshis or 0,
+        inp.sequence,
+        int(inp.sighash),
+    )
+
+
 def _inputs_to_tuples(inputs: list[TransactionInput]) -> list[tuple]:
+    """Input tuples for the native batch preimage of ALL inputs.
+
+    Every input is the signing input of its own preimage, so each locking_script
+    enters a digest; a missing one is a caller error, surfaced here exactly as
+    the pure-Python batch path does.
+    """
+    return [_input_to_tuple(inp, inp.locking_script.serialize()) for inp in inputs]
+
+
+def _inputs_to_tuples_for_input(inputs: list[TransactionInput], signing_index: int) -> list[tuple]:
+    """Input tuples for the native preimage of ONE signing input.
+
+    Only ``inputs[signing_index]``'s locking_script enters the digest (BIP143
+    scriptCode / OTDA scriptSig), so a missing one is surfaced as an error, matching
+    the pure-Python single-input path. The other inputs' scripts never enter this
+    digest — they contribute only outpoints (hashPrevouts) and sequences
+    (hashSequence) — so a missing one is replaced with ``b""`` instead of crashing.
+    This restores parity with the 2.2.x pure-Python behaviour for a tx parsed from
+    raw hex where only the signing input's prev-output has been restored (issue #187).
+    """
     return [
-        (
-            inp.source_txid,
-            inp.source_output_index,
-            inp.locking_script.serialize(),
-            inp.satoshis or 0,
-            inp.sequence,
-            int(inp.sighash),
+        _input_to_tuple(
+            inp,
+            inp.locking_script.serialize() if (i == signing_index or inp.locking_script) else b"",
         )
-        for inp in inputs
+        for i, inp in enumerate(inputs)
     ]
 
 
 def _outputs_to_bytes(outputs: list[TransactionOutput]) -> list[bytes]:
     return [out.serialize() for out in outputs]
+
+
+def _serialize_output_for_preimage(out: TransactionOutput, committed: bool) -> bytes:
+    """Serialize a single output for a native single-input preimage.
+
+    ``committed`` outputs (the ones the signing input's sighash actually digests)
+    are serialized as-is, so a genuinely missing amount still surfaces as an
+    error — matching the pure-Python path and avoiding a silently-wrong signature.
+    A *non-committed* output whose amount is not yet set (``satoshis is None``,
+    e.g. a change output restored from wire or awaiting ``fee()``) is serialized
+    with a zero-satoshis placeholder so the native path does not crash on a value
+    that never enters this input's digest.
+    """
+    if committed or out.satoshis is not None:
+        return out.serialize()
+    return b"".join(
+        [
+            (0).to_bytes(8, "little"),
+            out.locking_script.byte_length_varint(),
+            out.locking_script.serialize(),
+        ]
+    )
+
+
+def _outputs_to_bytes_for_input(outputs: list[TransactionOutput], input_index: int, sighash: int) -> list[bytes]:
+    """Serialize outputs for the native preimage of one signing input.
+
+    Mirrors the BIP143/OTDA output commitment of a single signing input:
+    SIGHASH_ALL digests every output, SIGHASH_SINGLE only ``outputs[input_index]``,
+    SIGHASH_NONE none. Only the committed outputs are serialized strictly; the
+    rest are serialized defensively (see :func:`_serialize_output_for_preimage`)
+    so an unfunded output elsewhere in the tx cannot crash the native path on an
+    amount this input never signs. For already-funded transactions this returns
+    exactly the same bytes as :func:`_outputs_to_bytes`.
+    """
+    base = sighash & 0x1F
+    commits_all = base != int(SIGHASH.NONE) and base != int(SIGHASH.SINGLE)
+    return [
+        _serialize_output_for_preimage(out, commits_all or (base == int(SIGHASH.SINGLE) and i == input_index))
+        for i, out in enumerate(outputs)
+    ]
 
 
 def tx_preimages(
@@ -236,13 +304,20 @@ def tx_preimage(
     if SIGHASH.use_otda(sighash):
         if _USE_NATIVE:
             return _bsv_native.tx_preimage_otda(
-                input_index, tx_version, tx_locktime, _inputs_to_tuples(inputs), _outputs_to_bytes(outputs)
+                input_index,
+                tx_version,
+                tx_locktime,
+                _inputs_to_tuples_for_input(inputs, input_index),
+                _outputs_to_bytes_for_input(outputs, input_index, sighash),
             )
         return _preimage_otda(input_index, inputs, outputs, tx_version, tx_locktime)
 
     if _USE_NATIVE:
         preimages = _bsv_native.tx_preimages(
-            tx_version, tx_locktime, _inputs_to_tuples(inputs), _outputs_to_bytes(outputs)
+            tx_version,
+            tx_locktime,
+            _inputs_to_tuples_for_input(inputs, input_index),
+            _outputs_to_bytes_for_input(outputs, input_index, sighash),
         )
         return preimages[input_index]
 

--- a/tests/bsv/native/test_equivalence.py
+++ b/tests/bsv/native/test_equivalence.py
@@ -386,6 +386,193 @@ class TestOTDAPreimageEquivalence:
 
 
 # ═══════════════════════════════════════════════════════════════════════
+# 6b. Regression: preimage() with an unrestored non-signing input (#187)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPreimageUnrestoredNonSigningInput:
+    """Regression for https://github.com/bsv-blockchain/py-sdk/issues/187.
+
+    When a transaction is parsed from raw hex, every input has
+    ``locking_script=None`` and ``satoshis=None``. Callers that restore the
+    prev-output script/value for ONLY the input they want to sign (the common
+    single-input signing flow) must still be able to call
+    ``Transaction.preimage(i)``. The native path used to crash in
+    ``_inputs_to_tuples()`` because it called ``locking_script.serialize()``
+    unconditionally on the non-signing input whose ``locking_script`` is None,
+    while the pure-Python path only ever read the signing input's script.
+
+    The fix (``_inputs_to_tuples_for_input``) replaces a *non-signing* input's
+    missing script with ``b""`` but still requires the *signing* input's own
+    script, matching the pure-Python path (which raises when the signing input's
+    script is missing). Both native BIP143 (``tx_preimages``) and native OTDA
+    (``tx_preimage_otda``) funnel through it.
+    """
+
+    LOCKING_SCRIPT = "76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac"
+    SATOSHIS = 100_000_000
+
+    SIGHASH_FLAGS = [
+        SIGHASH.ALL_FORKID,  # BIP143 routing
+        SIGHASH.NONE_FORKID,  # BIP143 routing
+        SIGHASH.SINGLE_FORKID,  # BIP143 routing
+        SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE,  # OTDA routing
+        SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE,  # OTDA routing
+        SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE,  # OTDA routing
+    ]
+
+    def _build(self, sighash):
+        # TX_2IN_3OUT parsed from hex -> every input locking_script/satoshis is None.
+        tx = Transaction.from_hex(TX_2IN_3OUT)
+        # Restore the prev-output script/value for the SIGNING input only.
+        tx.inputs[0].locking_script = Script.from_bytes(bytes.fromhex(self.LOCKING_SCRIPT))
+        tx.inputs[0].satoshis = self.SATOSHIS
+        tx.inputs[0].sighash = sighash
+        return tx
+
+    @pytest.mark.parametrize("sighash", SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}")
+    def test_preimage_native_matches_python(self, sighash):
+        import bsv.transaction_preimage as tp_mod
+
+        # Precondition: the non-signing input is genuinely unrestored.
+        guard = self._build(sighash)
+        assert guard.inputs[1].locking_script is None
+        assert guard.inputs[1].satoshis is None
+
+        orig = tp_mod._USE_NATIVE
+
+        # (a) Native path must not crash and must return a preimage.
+        tp_mod._USE_NATIVE = True
+        try:
+            native_preimage = self._build(sighash).preimage(0)
+        finally:
+            tp_mod._USE_NATIVE = orig
+        assert isinstance(native_preimage, bytes) and len(native_preimage) > 0
+
+        # (b) Pure-Python fallback yields the identical digest.
+        tp_mod._USE_NATIVE = False
+        try:
+            py_preimage = self._build(sighash).preimage(0)
+        finally:
+            tp_mod._USE_NATIVE = orig
+
+        assert native_preimage == py_preimage, f"preimage mismatch for sighash 0x{int(sighash):02x}"
+        assert py_hash256(native_preimage) == py_hash256(py_preimage)
+
+    @pytest.mark.parametrize("sighash", SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}")
+    def test_preimage_raises_when_signing_input_unrestored(self, sighash):
+        """The SIGNING input's own script must be present on both paths.
+
+        Substituting b"" for the signing input would silently produce a digest
+        over an empty scriptCode; instead both native and pure-Python must raise
+        (parity), so callers like the KVStore PushDrop unlocker keep skipping
+        inputs they cannot validly sign rather than emitting a garbage signature.
+        """
+        import bsv.transaction_preimage as tp_mod
+
+        # Signing input 0 is NOT restored -> its locking_script stays None.
+        tx = Transaction.from_hex(TX_2IN_3OUT)
+        tx.inputs[0].sighash = sighash
+        assert tx.inputs[0].locking_script is None
+
+        orig = tp_mod._USE_NATIVE
+        for use_native in (True, False):
+            tp_mod._USE_NATIVE = use_native
+            try:
+                with pytest.raises(AttributeError):
+                    tx.preimage(0)
+            finally:
+                tp_mod._USE_NATIVE = orig
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6c. Regression: preimage() with an unfunded (satoshis=None) output (#187 sibling)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPreimageUnfundedOutput:
+    """Regression sibling of #187 on the OUTPUT side.
+
+    The native preimage path used to serialize EVERY output eagerly, so an
+    unfunded output (``satoshis=None``, e.g. a change output awaiting ``fee()``)
+    crashed the native path even when the signing input's sighash does not
+    commit to that output — whereas the pure-Python path skips it (SIGHASH_NONE
+    commits no output; SIGHASH_SINGLE commits only ``outputs[input_index]``).
+
+    The fix serializes only the committed outputs strictly, so:
+      * a NON-committed unfunded output no longer crashes the native path, and
+        the native digest equals the pure-Python digest; and
+      * a COMMITTED unfunded amount still raises on BOTH paths (parity — never a
+        silently-wrong signature over amount 0).
+    """
+
+    LOCKING = "76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac"
+
+    SIGHASH_FLAGS = [
+        SIGHASH.ALL_FORKID,
+        SIGHASH.NONE_FORKID,
+        SIGHASH.SINGLE_FORKID,
+        SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE,
+        SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE,
+        SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE,
+    ]
+
+    def _build(self, sighash, none_output_index):
+        script = Script.from_bytes(bytes.fromhex(self.LOCKING))
+        outs = [
+            TransactionOutput(locking_script=script, satoshis=500),
+            TransactionOutput(locking_script=script, satoshis=600),
+        ]
+        outs[none_output_index].satoshis = None  # unfunded
+        tx = Transaction(
+            tx_inputs=[TransactionInput(source_txid="aa" * 32, source_output_index=0, sequence=0xFFFFFFFF)],
+            tx_outputs=outs,
+        )
+        tx.inputs[0].locking_script = script
+        tx.inputs[0].satoshis = 1000
+        tx.inputs[0].sighash = int(sighash)
+        return tx
+
+    def _preimage(self, sighash, none_output_index, use_native):
+        import bsv.transaction_preimage as tp_mod
+
+        orig = tp_mod._USE_NATIVE
+        tp_mod._USE_NATIVE = use_native
+        try:
+            return ("ok", self._build(sighash, none_output_index).preimage(0))
+        except Exception as e:  # parity check only compares the outcome kind
+            return ("err", type(e).__name__)
+        finally:
+            tp_mod._USE_NATIVE = orig
+
+    # none output at index 1 == NOT the signing input's SINGLE output; committed only under ALL.
+    # none output at index 0 == the signing input's SINGLE output; committed under ALL and SINGLE.
+    @pytest.mark.parametrize("none_output_index", [1, 0], ids=["none@non-committed", "none@committed"])
+    @pytest.mark.parametrize("sighash", SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}")
+    def test_native_matches_python(self, sighash, none_output_index):
+        native = self._preimage(sighash, none_output_index, True)
+        python = self._preimage(sighash, none_output_index, False)
+
+        # Native and pure-Python must agree on the outcome kind ...
+        assert native[0] == python[0], (
+            f"native={native} python={python} for sighash 0x{int(sighash):02x} "
+            f"none_output_index={none_output_index}"
+        )
+        # ... and, when both succeed, on the exact preimage bytes.
+        if native[0] == "ok":
+            assert native[1] == python[1]
+
+    def test_funded_outputs_are_unaffected(self):
+        """Sanity: with every output funded the fix is a pure no-op vs full serialization."""
+        from bsv.transaction_preimage import _outputs_to_bytes, _outputs_to_bytes_for_input
+
+        tx = self._build(SIGHASH.ALL_FORKID, none_output_index=0)
+        tx.outputs[0].satoshis = 500  # re-fund the one we blanked
+        for sighash in self.SIGHASH_FLAGS:
+            assert _outputs_to_bytes_for_input(tx.outputs, 0, int(sighash)) == _outputs_to_bytes(tx.outputs)
+
+
+# ═══════════════════════════════════════════════════════════════════════
 # 7. Merkle
 # ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Fixes #187 (found via Ordinalx test feedback) plus an adjacent output-side sibling on the same native (`_bsv_native`) preimage path.

Since the native path was introduced, `Transaction.preimage(i)` crashed with
`AttributeError: 'NoneType' object has no attribute 'serialize'` whenever **another**
input of the transaction had `locking_script=None` — e.g. a tx parsed from raw hex
with only the signing input's prev-output restored. This is a regression vs the
2.2.x pure-Python path, which only reads the **signing** input's locking script.

## Input side (#187)

`_inputs_to_tuples()` serialized **all** inputs' locking scripts unconditionally.
The issue's suggested blanket `... if inp.locking_script else b""` guard fixes the
crash, but it also substitutes `b""` for the **signing** input, producing a digest
over an empty scriptCode — diverging from the pure-Python path (which requires the
signing input's script) and emitting garbage signatures. This was observed breaking
`test_unlocking_script_length_estimate_vs_actual_set_and_remove`: the KVStore
PushDrop unlocker relied on the crash to skip inputs whose source it hadn't linked,
and the blanket guard turned those skips into 2-byte empty-signature spends.

The fix, `_inputs_to_tuples_for_input(inputs, signing_index)` (used by the
single-input `tx_preimage` for BIP143 + OTDA, and by `_calc_input_preimage_bip143_native`):

- a **non-signing** input's missing script → `b""` (it never enters input *i*'s
  digest; it contributes only outpoints via `hashPrevouts` and sequences via
  `hashSequence`);
- the **signing** input's script is still required and raises when absent, matching
  the pure-Python `_preimage` / `_build_bip143_preimage`.

Verified against the **ts-sdk** (`TransactionSignature.format` — `otherInputs` read
only outpoints/sequences) and **go-sdk** (`CalcInputPreimage` — only the signing
input's `SourceTxScript()` is serialized) BIP143 implementations, both of which
never read a non-signing input's script.

## Output side (sibling)

The native path also serialized **all** outputs eagerly, crashing on an unfunded
output (`satoshis=None`) even when the signing input's sighash does not commit to it
(`SIGHASH_NONE`, or a non-target output under `SIGHASH_SINGLE`) — whereas the
pure-Python path skips it. `_outputs_to_bytes_for_input()` now serializes only the
committed outputs strictly and defensively zero-fills a **non-committed** unfunded
amount. A **committed** missing amount still raises on both paths (fail-fast — no
silently-wrong `SIGHASH_ALL` signature over amount 0).

> Note: ts-sdk/go-sdk default every output amount to 0 (`satoshis ?? 0` / uint64
> zero value) rather than erroring, but that is a type-system artifact, not a
> deliberate "sign unfunded outputs" semantic. For every real (funded) transaction
> all three SDKs produce byte-identical digests; this PR keeps py-sdk's fail-fast
> safety for the pathological committed-unfunded case.

## Safety / parity

Both changes are **no-ops for every funded, restored transaction** — the native path
stays byte-identical to the pure-Python path — and only alter the previously-crashing
edge cases. The C extension is unaffected: outputs cross the boundary as
pre-serialized bytes and inputs as `(…, script_bytes, …)` tuples, so all `None`
handling is necessarily at the Python layer; `parse_input_tuple` already accepts
empty script bytes cleanly.

## Tests

Adds 25 regression tests in `tests/bsv/native/test_equivalence.py` covering BIP143
and OTDA routing for:

- unrestored **non-signing** input → native preimage == pure-Python preimage;
- unrestored **signing** input → both paths raise (parity, prevents garbage sigs);
- unfunded output, **committed vs non-committed** position → outcomes agree on both paths.

Full non-live suite: **3440 passed, 46 skipped**. `ruff` + `black` clean. The
previously-failing KVStore E2E test now passes.

Fixes #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
