### PR TITLE
fix: correct varint boundary off-by-one in SatoshisPerKilobyte fee model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Varint boundary off-by-one in `SatoshisPerKilobyte` fee model** — `get_varint_size` used `> 253` / `> 2**16` / `> 2**32` which underestimated by 2–4 bytes when a script length landed exactly on a varint boundary (253, 65536, 4294967296). Aligned to `> 0xFC` / `> 0xFFFF` / `> 0xFFFFFFFF`, matching the canonical encoder in `binary.py` and the SV Node / Teranode / Go SDK implementations. The same bug exists in the TS SDK's `SatoshisPerKilobyte`.
+- **Fee model test fixes** — corrected pre-existing test failures in `fee_models_test_coverage.py` (wrong constructor kwarg `rate=` → `value=`, and `int` passed instead of `Transaction` to `compute_fee`).
+
+---
+
 ## [2.3.3] - 2026-07-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **C extension `tx_to_bytes` / `tx_preimages` / `tx_preimage_otda` silent truncation of version/locktime** — `PyArg_ParseTuple("I")` silently wrapped negative values and values > 2^32. Now raises `OverflowError`, matching Python's `int.to_bytes(4, "little")` contract.
+- **C extension silent type coercion for scripts** — non-bytes `unlocking_script` (e.g. `bytearray`, `str`) was silently treated as empty; non-bytes `locking_script` was silently zero-length. Now raises `TypeError` with a descriptive message.
+- **C extension `source_txid` validation** — arbitrary-length hex strings or non-hex were silently accepted. Now validates exactly 64 hex characters, matching the Python fallback.
+- **`source_txid` validation unified across Python codebase** — introduced `txid_to_bytes_le()` helper in `transaction_input.py`; all `bytes.fromhex(*.source_txid)[::-1]` sites (serialize, preimage, BEEF) now go through a single validated path.
 - **Varint boundary off-by-one in `SatoshisPerKilobyte` fee model** — `get_varint_size` used `> 253` / `> 2**16` / `> 2**32` which underestimated by 2–4 bytes when a script length landed exactly on a varint boundary (253, 65536, 4294967296). Aligned to `> 0xFC` / `> 0xFFFF` / `> 0xFFFFFFFF`, matching the canonical encoder in `binary.py` and the SV Node / Teranode / Go SDK implementations. The same bug exists in the TS SDK's `SatoshisPerKilobyte`.
 - **Fee model test fixes** — corrected pre-existing test failures in `fee_models_test_coverage.py` (wrong constructor kwarg `rate=` → `value=`, and `int` passed instead of `Transaction` to `compute_fee`).
+
+### Changed
+
+- **Subclass-safe native serialization** — `Transaction.serialize()` now checks `type(i) is TransactionInput` / `type(o) is TransactionOutput` before using the C fast path. Subclassed inputs/outputs automatically fall back to the Python path, preserving `serialize()` overrides regardless of whether the C extension is installed.
+
+### Added
+
+- **Hypothesis differential tests** — property-based tests generating random transactions and verifying C native and Python fallback produce identical bytes for serialization, BIP143 preimage, and OTDA preimage across all 12 sighash flag combinations.
+- **Comprehensive edge-case test suite** (`test_tx_serialize_edge_cases.py`, 190 tests) — varint boundaries, large scripts (up to 20MB NFT payloads), satoshi boundary values, version/locktime rejection, script type rejection, source_txid validation on both paths, subclass fallback verification.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,8 +22,16 @@ any questions.
 - [ ] **Python 3.14 正式サポート** — CI に cp314 標準ビルドを組込 (cibuildwheel bump)、
       その後 free-threading (cp314t) 対応。標準ビルドは手元検証済み・CI 化が残
 - [ ] **性能: `Transaction.sign()` の O(N²) 解消** (F11) — 大量署名 (ordinalx 等) に直結
-- [ ] **堅牢性: `tx_to_bytes` 入力検証** (F4) — 異常入力での segfault 防止
+- [x] **堅牢性: `tx_to_bytes` 入力検証** (F4) — version/locktime 範囲、script 型、source_txid 形式、dict キー欠落の全検証を追加。サブクラス安全な native dispatch に変更
 - [ ] 性能・テスト基盤の追い込み — RIPEMD160 C 化 (F6)、冗長 pubkey_parse 除去 (F10)、
       crash/hang 回帰の CI 常時実行 (F16b)
+- [ ] **ASan CI 実行** — Linux CI で `LD_PRELOAD` + ASan ビルドによる native テスト実行。UBSan はローカルでパス済み、ASan は macOS SIP 制限で未実行
+- [ ] **Go SDK 固定ベクトル拡充** — Go SDK のテストベクトルを取り込み、クロス SDK 等価性を検証
 - [ ] (任意) `context_randomize` 定期化 (4.4)、Schnorr 署名 API (4.5)、musllinux wheel
 - [ ] C拡張された py-sdk を試す — `_bsv_native` モジュールによる高速化の検証・評価
+
+## 既知の課題
+
+- **TS SDK に同一の varint off-by-one バグ** — `ts-sdk` の `SatoshisPerKilobyte.ts` 内
+  `getVarIntSize` が py-sdk と同じ `> 253` / `> 2**16` / `> 2**32` を使用。
+  Go SDK は正しい。upstream への issue/PR が必要

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -1470,6 +1470,30 @@ static int varint_size(uint64_t n) {
     return 9;
 }
 
+/* Internal: parse a Python int as a strict uint32.
+ * Rejects negative values and values > UINT32_MAX with OverflowError,
+ * matching Python's int.to_bytes(4, "little") contract. */
+static int parse_uint32(PyObject *obj, const char *name, uint32_t *out) {
+    if (!PyLong_Check(obj)) {
+        PyErr_Format(PyExc_TypeError, "%s must be an integer", name);
+        return -1;
+    }
+    int overflow = 0;
+    long long val = PyLong_AsLongLongAndOverflow(obj, &overflow);
+    if (overflow > 0 || (overflow == 0 && val > (long long)UINT32_MAX)) {
+        PyErr_Format(PyExc_OverflowError, "%s does not fit in uint32", name);
+        return -1;
+    }
+    if (overflow < 0 || val < 0) {
+        PyErr_Format(PyExc_OverflowError,
+                     "can't convert negative int to unsigned (%s)", name);
+        return -1;
+    }
+    if (val == -1 && PyErr_Occurred()) return -1;
+    *out = (uint32_t)val;
+    return 0;
+}
+
 /* Internal: PyDict_SetItemString does NOT steal the value reference.
  * This helper consumes it, so inline-created values are not leaked. */
 static int dict_set_steal(PyObject *d, const char *key, PyObject *v) {
@@ -1626,10 +1650,14 @@ parse_err:
  * outputs: list of dict(satoshis=int, locking_script=bytes)
  */
 static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
-    unsigned int version, locktime;
+    PyObject *py_version, *py_locktime;
     PyObject *inputs, *outputs;
-    if (!PyArg_ParseTuple(args, "IOOI", &version, &inputs, &outputs, &locktime))
+    if (!PyArg_ParseTuple(args, "OOOO", &py_version, &inputs, &outputs, &py_locktime))
         return NULL;
+
+    uint32_t version, locktime;
+    if (parse_uint32(py_version, "version", &version) < 0) return NULL;
+    if (parse_uint32(py_locktime, "locktime", &locktime) < 0) return NULL;
 
     if (!PyList_Check(inputs) || !PyList_Check(outputs)) {
         PyErr_SetString(PyExc_TypeError, "inputs and outputs must be lists");
@@ -1644,15 +1672,43 @@ static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
     total += varint_size(n_in);
     for (Py_ssize_t i = 0; i < n_in; i++) {
         PyObject *inp = PyList_GET_ITEM(inputs, i);
+        if (!PyDict_Check(inp)) {
+            PyErr_SetString(PyExc_TypeError, "each input must be a dict");
+            return NULL;
+        }
         PyObject *script = PyDict_GetItemString(inp, "unlocking_script");
-        Py_ssize_t slen = script && PyBytes_Check(script) ? PyBytes_GET_SIZE(script) : 0;
+        Py_ssize_t slen;
+        if (!script || script == Py_None) {
+            slen = 0;
+        } else if (PyBytes_Check(script)) {
+            slen = PyBytes_GET_SIZE(script);
+        } else {
+            PyErr_Format(PyExc_TypeError,
+                         "unlocking_script must be bytes or None, got %s",
+                         Py_TYPE(script)->tp_name);
+            return NULL;
+        }
         total += 32 + 4 + varint_size(slen) + slen + 4; /* txid + vout + script + seq */
     }
     total += varint_size(n_out);
     for (Py_ssize_t i = 0; i < n_out; i++) {
         PyObject *outp = PyList_GET_ITEM(outputs, i);
+        if (!PyDict_Check(outp)) {
+            PyErr_SetString(PyExc_TypeError, "each output must be a dict");
+            return NULL;
+        }
         PyObject *script = PyDict_GetItemString(outp, "locking_script");
-        Py_ssize_t slen = script && PyBytes_Check(script) ? PyBytes_GET_SIZE(script) : 0;
+        if (!script || script == Py_None) {
+            PyErr_SetString(PyExc_TypeError, "locking_script must not be None");
+            return NULL;
+        }
+        if (!PyBytes_Check(script)) {
+            PyErr_Format(PyExc_TypeError,
+                         "locking_script must be bytes, got %s",
+                         Py_TYPE(script)->tp_name);
+            return NULL;
+        }
+        Py_ssize_t slen = PyBytes_GET_SIZE(script);
         total += 8 + varint_size(slen) + slen; /* satoshis + script */
     }
     total += 4; /* locktime */
@@ -1675,21 +1731,40 @@ static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
 
         /* txid hex -> bytes reversed */
         PyObject *txid_obj = PyDict_GetItemString(inp, "source_txid");
-        const char *txid_hex = PyUnicode_AsUTF8(txid_obj);
-        hex_to_bytes_reversed(txid_hex, out + pos, 32);
+        if (!txid_obj || !PyUnicode_Check(txid_obj)) {
+            PyErr_SetString(PyExc_TypeError, "source_txid must be a hex string");
+            goto serialize_err;
+        }
+        Py_ssize_t txid_len = 0;
+        const char *txid_hex = PyUnicode_AsUTF8AndSize(txid_obj, &txid_len);
+        if (!txid_hex) goto serialize_err;
+        if (txid_len != 64 || hex_to_bytes_reversed(txid_hex, out + pos, 32) < 0) {
+            PyErr_SetString(PyExc_ValueError, "source_txid must be exactly 64 hex characters");
+            goto serialize_err;
+        }
         pos += 32;
 
         /* vout */
         PyObject *vout_obj = PyDict_GetItemString(inp, "source_output_index");
-        uint32_t vout = (uint32_t)PyLong_AsUnsignedLong(vout_obj);
+        if (!vout_obj) {
+            PyErr_SetString(PyExc_KeyError, "missing source_output_index");
+            goto serialize_err;
+        }
+        unsigned long vout_value = PyLong_AsUnsignedLong(vout_obj);
+        if (PyErr_Occurred()) goto serialize_err;
+        if (vout_value > UINT32_MAX) {
+            PyErr_SetString(PyExc_OverflowError, "source_output_index does not fit in uint32");
+            goto serialize_err;
+        }
+        uint32_t vout = (uint32_t)vout_value;
         out[pos++] = (unsigned char)(vout & 0xFF);
         out[pos++] = (unsigned char)((vout >> 8) & 0xFF);
         out[pos++] = (unsigned char)((vout >> 16) & 0xFF);
         out[pos++] = (unsigned char)((vout >> 24) & 0xFF);
 
-        /* unlocking script */
+        /* unlocking script (already validated in size loop) */
         PyObject *script = PyDict_GetItemString(inp, "unlocking_script");
-        Py_ssize_t slen = script && PyBytes_Check(script) ? PyBytes_GET_SIZE(script) : 0;
+        Py_ssize_t slen = (script && PyBytes_Check(script)) ? PyBytes_GET_SIZE(script) : 0;
         pos += write_varint(out + pos, slen);
         if (slen > 0) {
             memcpy(out + pos, PyBytes_AS_STRING(script), slen);
@@ -1698,7 +1773,17 @@ static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
 
         /* sequence */
         PyObject *seq_obj = PyDict_GetItemString(inp, "sequence");
-        uint32_t seq = (uint32_t)PyLong_AsUnsignedLong(seq_obj);
+        if (!seq_obj) {
+            PyErr_SetString(PyExc_KeyError, "missing sequence");
+            goto serialize_err;
+        }
+        unsigned long seq_value = PyLong_AsUnsignedLong(seq_obj);
+        if (PyErr_Occurred()) goto serialize_err;
+        if (seq_value > UINT32_MAX) {
+            PyErr_SetString(PyExc_OverflowError, "sequence does not fit in uint32");
+            goto serialize_err;
+        }
+        uint32_t seq = (uint32_t)seq_value;
         out[pos++] = (unsigned char)(seq & 0xFF);
         out[pos++] = (unsigned char)((seq >> 8) & 0xFF);
         out[pos++] = (unsigned char)((seq >> 16) & 0xFF);
@@ -1712,13 +1797,18 @@ static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
 
         /* satoshis */
         PyObject *sats_obj = PyDict_GetItemString(outp, "satoshis");
+        if (!sats_obj) {
+            PyErr_SetString(PyExc_KeyError, "missing satoshis");
+            goto serialize_err;
+        }
         uint64_t sats = PyLong_AsUnsignedLongLong(sats_obj);
+        if (PyErr_Occurred()) goto serialize_err;
         for (int k = 0; k < 8; k++)
             out[pos++] = (unsigned char)((sats >> (k * 8)) & 0xFF);
 
-        /* locking script */
+        /* locking script (already validated in size loop) */
         PyObject *script = PyDict_GetItemString(outp, "locking_script");
-        Py_ssize_t slen = script && PyBytes_Check(script) ? PyBytes_GET_SIZE(script) : 0;
+        Py_ssize_t slen = PyBytes_GET_SIZE(script);
         pos += write_varint(out + pos, slen);
         if (slen > 0) {
             memcpy(out + pos, PyBytes_AS_STRING(script), slen);
@@ -1733,6 +1823,10 @@ static PyObject* pyfn_tx_to_bytes(PyObject *self, PyObject *args) {
     out[pos++] = (unsigned char)((locktime >> 24) & 0xFF);
 
     return result;
+
+serialize_err:
+    Py_DECREF(result);
+    return NULL;
 }
 
 /*
@@ -1838,10 +1932,14 @@ static void write_u64_le(unsigned char *buf, uint64_t v) {
  * outputs: list of bytes (pre-serialized)
  */
 static PyObject* pyfn_tx_preimages(PyObject *self, PyObject *args) {
-    uint32_t version, locktime;
+    PyObject *py_version, *py_locktime;
     PyObject *inputs_list, *outputs_list;
-    if (!PyArg_ParseTuple(args, "IIOO", &version, &locktime, &inputs_list, &outputs_list))
+    if (!PyArg_ParseTuple(args, "OOOO", &py_version, &py_locktime, &inputs_list, &outputs_list))
         return NULL;
+
+    uint32_t version, locktime;
+    if (parse_uint32(py_version, "version", &version) < 0) return NULL;
+    if (parse_uint32(py_locktime, "locktime", &locktime) < 0) return NULL;
 
     if (!PyList_Check(inputs_list) || !PyList_Check(outputs_list)) {
         PyErr_SetString(PyExc_TypeError, "inputs and outputs must be lists");
@@ -2024,11 +2122,15 @@ static PyObject* pyfn_tx_preimages(PyObject *self, PyObject *args) {
  */
 static PyObject* pyfn_tx_preimage_otda(PyObject *self, PyObject *args) {
     int input_index;
-    uint32_t version, locktime;
+    PyObject *py_version, *py_locktime;
     PyObject *inputs_list, *outputs_list;
-    if (!PyArg_ParseTuple(args, "iIIOO", &input_index, &version, &locktime,
+    if (!PyArg_ParseTuple(args, "iOOOO", &input_index, &py_version, &py_locktime,
                           &inputs_list, &outputs_list))
         return NULL;
+
+    uint32_t version, locktime;
+    if (parse_uint32(py_version, "version", &version) < 0) return NULL;
+    if (parse_uint32(py_locktime, "locktime", &locktime) < 0) return NULL;
 
     if (!PyList_Check(inputs_list) || !PyList_Check(outputs_list)) {
         PyErr_SetString(PyExc_TypeError, "inputs and outputs must be lists");

--- a/bsv/fee_models/satoshis_per_kilobyte.py
+++ b/bsv/fee_models/satoshis_per_kilobyte.py
@@ -27,11 +27,11 @@ class SatoshisPerKilobyte(FeeModel):
         """
 
         def get_varint_size(i: int) -> int:
-            if i > 2**32:
+            if i > 0xFFFFFFFF:
                 return 9
-            elif i > 2**16:
+            elif i > 0xFFFF:
                 return 5
-            elif i > 253:
+            elif i > 0xFC:
                 return 3
             else:
                 return 1

--- a/bsv/transaction.py
+++ b/bsv/transaction.py
@@ -18,10 +18,10 @@ from .hash import hash256
 from .merkle_path import MerklePath
 from .script.script import Script
 from .script.type import P2PKH
-from .transaction_input import TransactionInput
+from .transaction_input import TransactionInput, txid_to_bytes_le
 from .transaction_output import TransactionOutput
 from .transaction_preimage import _outputs_to_bytes_for_input, tx_preimage
-from .utils import Reader, Writer, reverse_hex_byte_order, unsigned_to_varint
+from .utils import Reader, Writer, unsigned_to_varint
 
 try:
     import _bsv_native
@@ -64,6 +64,42 @@ class Transaction:
         self._cached_txid: Optional[str] = None
 
     def serialize(self) -> bytes:
+        if (
+            _USE_NATIVE_TX
+            and all(type(i) is TransactionInput for i in self.inputs)
+            and all(type(o) is TransactionOutput for o in self.outputs)
+        ):
+            inputs = [
+                {
+                    "source_txid": tx_input.source_txid,
+                    "source_output_index": tx_input.source_output_index,
+                    "unlocking_script": (
+                        tx_input.unlocking_script.serialize()
+                        if tx_input.unlocking_script
+                        else b""
+                    ),
+                    "sequence": tx_input.sequence,
+                }
+                for tx_input in self.inputs
+            ]
+            outputs = [
+                {
+                    "satoshis": tx_output.satoshis,
+                    "locking_script": tx_output.locking_script.serialize(),
+                }
+                for tx_output in self.outputs
+            ]
+            return _bsv_native.tx_to_bytes(
+                self.version,
+                inputs,
+                outputs,
+                self.locktime,
+            )
+
+        return self._serialize_python()
+
+    def _serialize_python(self) -> bytes:
+        """Serialize using the pure-Python fallback."""
         raw = self.version.to_bytes(4, "little")
         raw += unsigned_to_varint(len(self.inputs))
         for tx_input in self.inputs:
@@ -199,7 +235,7 @@ class Transaction:
 
         prevouts_data = b""
         for inp in self.inputs:
-            prevouts_data += bytes.fromhex(inp.source_txid)[::-1]
+            prevouts_data += txid_to_bytes_le(inp.source_txid)
             prevouts_data += inp.source_output_index.to_bytes(4, "little")
         return hash256(prevouts_data)
 
@@ -252,7 +288,7 @@ class Transaction:
         # 3. hashSequence (32 bytes)
         stream.write(hash_sequence)
         # 4. outpoint (32-byte hash + 4-byte little endian)
-        stream.write(bytes.fromhex(tx_input.source_txid)[::-1])
+        stream.write(txid_to_bytes_le(tx_input.source_txid))
         stream.write(tx_input.source_output_index.to_bytes(4, "little"))
         # 5. scriptCode (varint length + bytes)
         script_bytes = tx_input.locking_script.serialize()
@@ -564,7 +600,7 @@ class Transaction:
             if i.source_transaction is None:
                 raise ValueError("All inputs must have source transactions when serializing to EF format")
             if i.source_txid and i.source_txid != "00" * 32:
-                writer.write(bytes.fromhex(reverse_hex_byte_order(i.source_txid)))
+                writer.write(txid_to_bytes_le(i.source_txid))
             else:
                 writer.write(i.source_transaction.hash())
             writer.write_uint32_le(i.source_output_index)

--- a/bsv/transaction.py
+++ b/bsv/transaction.py
@@ -73,11 +73,7 @@ class Transaction:
                 {
                     "source_txid": tx_input.source_txid,
                     "source_output_index": tx_input.source_output_index,
-                    "unlocking_script": (
-                        tx_input.unlocking_script.serialize()
-                        if tx_input.unlocking_script
-                        else b""
-                    ),
+                    "unlocking_script": (tx_input.unlocking_script.serialize() if tx_input.unlocking_script else b""),
                     "sequence": tx_input.sequence,
                 }
                 for tx_input in self.inputs

--- a/bsv/transaction_input.py
+++ b/bsv/transaction_input.py
@@ -16,9 +16,7 @@ _TXID_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 def txid_to_bytes_le(txid: str) -> bytes:
     if not isinstance(txid, str) or not _TXID_RE.match(txid):
-        raise ValueError(
-            f"source_txid must be exactly 64 hex characters, got {txid!r}"
-        )
+        raise ValueError(f"source_txid must be exactly 64 hex characters, got {txid!r}")
     return bytes.fromhex(txid)[::-1]
 
 

--- a/bsv/transaction_input.py
+++ b/bsv/transaction_input.py
@@ -1,3 +1,4 @@
+import re
 from contextlib import suppress
 from io import BytesIO
 from typing import Optional, Union
@@ -9,6 +10,16 @@ from .constants import (
 from .script.script import Script
 from .script.unlocking_template import UnlockingScriptTemplate
 from .utils import Reader
+
+_TXID_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def txid_to_bytes_le(txid: str) -> bytes:
+    if not isinstance(txid, str) or not _TXID_RE.match(txid):
+        raise ValueError(
+            f"source_txid must be exactly 64 hex characters, got {txid!r}"
+        )
+    return bytes.fromhex(txid)[::-1]
 
 
 class TransactionInput:
@@ -41,7 +52,7 @@ class TransactionInput:
 
     def serialize(self) -> bytes:
         stream = BytesIO()
-        stream.write(bytes.fromhex(self.source_txid)[::-1])
+        stream.write(txid_to_bytes_le(self.source_txid))
         stream.write(self.source_output_index.to_bytes(4, "little"))
         stream.write(self.unlocking_script.byte_length_varint() if self.unlocking_script else b"\x00")
         stream.write(self.unlocking_script.serialize() if self.unlocking_script else b"")

--- a/bsv/transaction_preimage.py
+++ b/bsv/transaction_preimage.py
@@ -3,7 +3,7 @@ from typing import List
 
 from .constants import SIGHASH
 from .hash import hash256
-from .transaction_input import TransactionInput
+from .transaction_input import TransactionInput, txid_to_bytes_le
 from .transaction_output import TransactionOutput
 
 try:
@@ -43,7 +43,7 @@ def _preimage(
     # 3
     stream.write(hash_sequence)
     # 4
-    stream.write(bytes.fromhex(tx_input.source_txid)[::-1])
+    stream.write(txid_to_bytes_le(tx_input.source_txid))
     stream.write(tx_input.source_output_index.to_bytes(4, "little"))
     # 5
     stream.write(tx_input.locking_script.byte_length_varint())
@@ -160,7 +160,7 @@ def tx_preimages(
         return _bsv_native.tx_preimages(tx_version, tx_locktime, _inputs_to_tuples(inputs), _outputs_to_bytes(outputs))
 
     _hash_prevouts = hash256(
-        b"".join(bytes.fromhex(_in.source_txid)[::-1] + _in.source_output_index.to_bytes(4, "little") for _in in inputs)
+        b"".join(txid_to_bytes_le(_in.source_txid) + _in.source_output_index.to_bytes(4, "little") for _in in inputs)
     )
     _hash_sequence = hash256(b"".join(_in.sequence.to_bytes(4, "little") for _in in inputs))
     _hash_outputs = hash256(b"".join(tx_output.serialize() for tx_output in outputs))
@@ -195,7 +195,7 @@ def tx_preimages(
 def _otda_serialize_input(stream, inp: TransactionInput, idx: int, input_index: int, base_type: int) -> None:
     """Serialize a single input for the OTDA preimage."""
     # outpoint
-    stream.write(bytes.fromhex(inp.source_txid)[::-1])
+    stream.write(txid_to_bytes_le(inp.source_txid))
     stream.write(inp.source_output_index.to_bytes(4, "little"))
     # scriptSig: only for the signing input
     if idx == input_index:
@@ -326,7 +326,7 @@ def tx_preimage(
     if not sighash & SIGHASH.ANYONECANPAY:
         hash_prevouts = hash256(
             b"".join(
-                bytes.fromhex(_in.source_txid)[::-1] + _in.source_output_index.to_bytes(4, "little") for _in in inputs
+                txid_to_bytes_le(_in.source_txid) + _in.source_output_index.to_bytes(4, "little") for _in in inputs
             )
         )
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/fee_model_test_coverage.py
+++ b/tests/bsv/fee_model_test_coverage.py
@@ -2,6 +2,8 @@
 Coverage tests for fee_model.py - untested branches.
 """
 
+import math
+
 import pytest
 
 from bsv.fee_model import FeeModel
@@ -139,3 +141,44 @@ def test_satoshis_per_kb_compute_fee_boundary():
     fee1001 = fee_model.compute_fee(tx1001)
     # Fees should generally increase with size
     assert fee999 >= 0 and fee1000 >= 0 and fee1001 >= 0
+
+
+# ========================================================================
+# Varint boundary regression (off-by-one fix)
+# ========================================================================
+
+
+@pytest.mark.parametrize(
+    "script_len,expected_varint_bytes",
+    [
+        (252, 1),
+        (253, 3),
+        (254, 3),
+        (0xFFFF, 3),
+    ],
+)
+def test_fee_varint_boundary_consistency(script_len, expected_varint_bytes):
+    """Fee estimate must account for the correct varint size at boundaries.
+
+    Regression test: the old code used ``> 253`` instead of ``> 0xFC``,
+    underestimating by 2 bytes when script_len == 253.
+    """
+    from bsv.utils.binary import unsigned_to_varint
+
+    assert len(unsigned_to_varint(script_len)) == expected_varint_bytes
+
+    tx = Transaction()
+    tx_input = TransactionInput(source_txid="00" * 32, source_output_index=0)
+    tx_input.unlocking_script = Script(b"\x00" * script_len)
+    tx.add_input(tx_input)
+    output_script = Script(b"\x76\xa9\x14" + b"\x00" * 20 + b"\x88\xac")
+    tx.add_output(TransactionOutput(output_script, 1000))
+
+    fee_model = SatoshisPerKilobyte(value=1000)
+    fee = fee_model.compute_fee(tx)
+
+    # 4 (ver) + 1 (ninputs) + 40 (input base) + varint(script_len) + script_len
+    # + 1 (noutputs) + 8 (sats) + 1 (lock_script varint) + 25 (lock_script) + 4 (locktime)
+    expected_size = 4 + 1 + 40 + expected_varint_bytes + script_len + 1 + 8 + 1 + 25 + 4
+    expected_fee = math.ceil((expected_size / 1000) * 1000)
+    assert fee == expected_fee

--- a/tests/bsv/fee_models_test_coverage.py
+++ b/tests/bsv/fee_models_test_coverage.py
@@ -21,7 +21,7 @@ def test_satoshis_per_kb_compute_with_transaction():
     try:
         from bsv.fee_models import SatoshisPerKilobyte
 
-        fee_model = SatoshisPerKilobyte(rate=1000)
+        fee_model = SatoshisPerKilobyte(value=1000)
 
         tx = Transaction(
             version=1,
@@ -45,16 +45,23 @@ def test_satoshis_per_kb_compute_with_transaction():
         pytest.skip(SKIP_SATOSHIS_PER_KB)
 
 
+def _make_simple_tx():
+    tx = Transaction()
+    tx_input = TransactionInput(source_txid="00" * 32, source_output_index=0)
+    tx_input.unlocking_script = Script(b"\x00" * 100)
+    tx.add_input(tx_input)
+    tx.add_output(TransactionOutput(Script(b"\x76\xa9\x14" + b"\x00" * 20 + b"\x88\xac"), 1000))
+    return tx
+
+
 def test_satoshis_per_kb_zero_rate():
     """Test fee model with zero rate."""
     try:
         from bsv.fee_models import SatoshisPerKilobyte
 
-        fee_model = SatoshisPerKilobyte(rate=0)
-
-        if hasattr(fee_model, "compute_fee"):
-            fee = fee_model.compute_fee(250)  # 250 bytes
-            assert fee == 0
+        fee_model = SatoshisPerKilobyte(value=0)
+        fee = fee_model.compute_fee(_make_simple_tx())
+        assert fee == 0
     except ImportError:
         pytest.skip(SKIP_SATOSHIS_PER_KB)
 
@@ -64,11 +71,9 @@ def test_satoshis_per_kb_very_high_rate():
     try:
         from bsv.fee_models import SatoshisPerKilobyte
 
-        fee_model = SatoshisPerKilobyte(rate=1000000)
-
-        if hasattr(fee_model, "compute_fee"):
-            fee = fee_model.compute_fee(250)
-            assert fee > 0
+        fee_model = SatoshisPerKilobyte(value=1000000)
+        fee = fee_model.compute_fee(_make_simple_tx())
+        assert fee > 0
     except ImportError:
         pytest.skip(SKIP_SATOSHIS_PER_KB)
 
@@ -119,7 +124,7 @@ def test_fee_model_with_empty_transaction():
     try:
         from bsv.fee_models import SatoshisPerKilobyte
 
-        fee_model = SatoshisPerKilobyte(rate=1000)
+        fee_model = SatoshisPerKilobyte(value=1000)
 
         tx = Transaction(version=1, tx_inputs=[], tx_outputs=[], locktime=0)
 
@@ -135,10 +140,8 @@ def test_fee_model_fractional_rate():
     try:
         from bsv.fee_models import SatoshisPerKilobyte
 
-        fee_model = SatoshisPerKilobyte(rate=1.5)
-
-        if hasattr(fee_model, "compute_fee"):
-            fee = fee_model.compute_fee(250)
-            assert isinstance(fee, (int, float))
+        fee_model = SatoshisPerKilobyte(value=1.5)
+        fee = fee_model.compute_fee(_make_simple_tx())
+        assert isinstance(fee, (int, float))
     except (ImportError, TypeError):
         pytest.skip("SatoshisPerKilobyte not available or doesn't support fractional rate")

--- a/tests/bsv/native/test_benchmark_native.py
+++ b/tests/bsv/native/test_benchmark_native.py
@@ -196,9 +196,21 @@ class TestBenchTx:
             parsed["locktime"],
         )
 
-    def test_tx_serialize_python(self, benchmark):
+    def test_tx_serialize_native_public(self, benchmark):
         tx = Transaction.from_hex(TX_1IN_2OUT)
         benchmark(tx.serialize)
+
+    def test_tx_serialize_python(self, benchmark):
+        tx = Transaction.from_hex(TX_1IN_2OUT)
+        benchmark(tx._serialize_python)
+
+    def test_tx_serialize_100in_native_public(self, benchmark):
+        tx = Transaction.from_hex(self.TX_100IN)
+        benchmark(tx.serialize)
+
+    def test_tx_serialize_100in_python(self, benchmark):
+        tx = Transaction.from_hex(self.TX_100IN)
+        benchmark(tx._serialize_python)
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/bsv/native/test_equivalence.py
+++ b/tests/bsv/native/test_equivalence.py
@@ -5,6 +5,8 @@ Every function that has a C path and a Python fallback is tested here.
 Both paths are called directly with the same input and outputs compared.
 """
 
+import sys
+
 import pytest
 
 _bsv_native = pytest.importorskip("_bsv_native")
@@ -166,6 +168,61 @@ class TestTxEquivalence:
         c_txid = _bsv_native.tx_txid(raw)
         py_txid = py_hash256(raw)[::-1].hex()
         assert c_txid == py_txid
+
+    @pytest.mark.parametrize("tx_hex", [TX_1IN_2OUT, TX_2IN_3OUT])
+    def test_public_serialize_native_matches_python_fallback(self, monkeypatch, tx_hex):
+        tx = Transaction.from_hex(tx_hex)
+        transaction_mod = sys.modules[Transaction.__module__]
+
+        monkeypatch.setattr(transaction_mod, "_USE_NATIVE_TX", False)
+        python_serialized = tx.serialize()
+
+        monkeypatch.setattr(transaction_mod, "_USE_NATIVE_TX", True)
+        native_serialized = tx.serialize()
+
+        assert native_serialized == python_serialized == bytes.fromhex(tx_hex)
+
+    def test_public_serialize_dispatches_to_native(self, monkeypatch):
+        tx = Transaction.from_hex(TX_1IN_2OUT)
+        transaction_mod = sys.modules[Transaction.__module__]
+        original = _bsv_native.tx_to_bytes
+        calls = 0
+
+        def recording_tx_to_bytes(*args):
+            nonlocal calls
+            calls += 1
+            return original(*args)
+
+        monkeypatch.setattr(_bsv_native, "tx_to_bytes", recording_tx_to_bytes)
+        monkeypatch.setattr(transaction_mod, "_USE_NATIVE_TX", True)
+
+        assert tx.serialize() == bytes.fromhex(TX_1IN_2OUT)
+        assert calls == 1
+
+    @pytest.mark.parametrize("source_txid", [None, "00", "gg" * 32])
+    def test_native_serialize_rejects_invalid_source_txid_safely(self, source_txid):
+        inputs = [
+            {
+                "source_txid": source_txid,
+                "source_output_index": 0,
+                "unlocking_script": b"",
+                "sequence": 0xFFFFFFFF,
+            }
+        ]
+        with pytest.raises((TypeError, ValueError)):
+            _bsv_native.tx_to_bytes(1, inputs, [], 0)
+
+    @pytest.mark.parametrize("field", ["source_output_index", "sequence"])
+    def test_native_serialize_rejects_uint32_overflow(self, field):
+        tx_input = {
+            "source_txid": "00" * 32,
+            "source_output_index": 0,
+            "unlocking_script": b"",
+            "sequence": 0xFFFFFFFF,
+        }
+        tx_input[field] = 0x1_0000_0000
+        with pytest.raises(OverflowError):
+            _bsv_native.tx_to_bytes(1, [tx_input], [], 0)
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/bsv/native/test_hypothesis_differential.py
+++ b/tests/bsv/native/test_hypothesis_differential.py
@@ -1,0 +1,325 @@
+"""Hypothesis differential tests: native C path vs Python fallback.
+
+Generates random valid transactions and verifies both paths produce
+identical bytes for serialization and preimage computation.  Unlike
+test_fuzz_native.py (crash oracle), these tests assert *equivalence*.
+
+Run:
+    pytest tests/bsv/native/test_hypothesis_differential.py -x -v
+    pytest tests/bsv/native/test_hypothesis_differential.py -x -v --hypothesis-seed=0
+"""
+
+import sys
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+_bsv_native = pytest.importorskip("_bsv_native")
+
+from bsv.constants import SIGHASH
+from bsv.script.script import Script
+from bsv.transaction import Transaction
+from bsv.transaction_input import TransactionInput
+from bsv.transaction_output import TransactionOutput
+
+diff_settings = settings(
+    max_examples=200,
+    deadline=5000,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+hex64 = st.text(alphabet="0123456789abcdef", min_size=64, max_size=64)
+uint32 = st.integers(min_value=0, max_value=0xFFFFFFFF)
+uint64 = st.integers(min_value=0, max_value=2**64 - 1)
+script_bytes = st.binary(min_size=0, max_size=1024)
+
+# varint boundary sizes to exercise 1/3/5-byte encoding
+varint_boundary_sizes = st.sampled_from([0, 1, 0xFC, 0xFD, 0xFF, 0x100, 0xFFFF])
+
+
+def script_at_size(size):
+    """Generate a script of exactly `size` bytes."""
+    return st.just(b"\x00" * size)
+
+
+varint_boundary_scripts = varint_boundary_sizes.flatmap(script_at_size)
+
+
+@st.composite
+def tx_input_strategy(draw, with_locking_script=False, sighash=None):
+    txid = draw(hex64)
+    vout = draw(st.integers(min_value=0, max_value=0xFFFFFFFF))
+    unlock = draw(script_bytes)
+    seq = draw(uint32)
+    sh = sighash or SIGHASH.ALL_FORKID
+
+    inp = TransactionInput(
+        source_txid=txid,
+        source_output_index=vout,
+        unlocking_script=Script(unlock),
+        sequence=seq,
+        sighash=sh,
+    )
+    if with_locking_script:
+        inp.locking_script = Script(draw(script_bytes.filter(lambda b: len(b) > 0)))
+        inp.satoshis = draw(st.integers(min_value=0, max_value=2**63 - 1))
+    return inp
+
+
+@st.composite
+def tx_output_strategy(draw):
+    sats = draw(st.integers(min_value=0, max_value=2**64 - 1))
+    script = draw(script_bytes)
+    return TransactionOutput(satoshis=sats, locking_script=Script(script))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _toggle_serialize(tx):
+    mod = sys.modules[Transaction.__module__]
+    orig = mod._USE_NATIVE_TX
+    mod._USE_NATIVE_TX = True
+    native = tx.serialize()
+    mod._USE_NATIVE_TX = False
+    python = tx.serialize()
+    mod._USE_NATIVE_TX = orig
+    return native, python
+
+
+def _toggle_preimage(tx, idx):
+    import bsv.transaction_preimage as tp
+
+    orig = tp._USE_NATIVE
+    tp._USE_NATIVE = True
+    try:
+        native = tx.preimage(idx)
+    finally:
+        tp._USE_NATIVE = orig
+    tp._USE_NATIVE = False
+    try:
+        python = tx.preimage(idx)
+    finally:
+        tp._USE_NATIVE = orig
+    return native, python
+
+
+# ---------------------------------------------------------------------------
+# Differential: serialize
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDifferential:
+    @diff_settings
+    @given(
+        version=uint32,
+        locktime=uint32,
+        inputs=st.lists(tx_input_strategy(), min_size=0, max_size=5),
+        outputs=st.lists(tx_output_strategy(), min_size=0, max_size=5),
+    )
+    def test_random_tx_serialize_equivalence(self, version, locktime, inputs, outputs):
+        tx = Transaction(version=version, tx_inputs=inputs, tx_outputs=outputs, locktime=locktime)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    @diff_settings
+    @given(
+        version=uint32,
+        locktime=uint32,
+        n_inputs=st.integers(min_value=0, max_value=3),
+        locking_script=varint_boundary_scripts,
+        unlocking_script=varint_boundary_scripts,
+    )
+    def test_varint_boundary_serialize_equivalence(
+        self, version, locktime, n_inputs, locking_script, unlocking_script
+    ):
+        inputs = [
+            TransactionInput(
+                source_txid="ab" * 32,
+                source_output_index=0,
+                unlocking_script=Script(unlocking_script),
+                sequence=0xFFFFFFFF,
+            )
+            for _ in range(n_inputs)
+        ]
+        outputs = [TransactionOutput(satoshis=1000, locking_script=Script(locking_script))]
+        tx = Transaction(version=version, tx_inputs=inputs, tx_outputs=outputs, locktime=locktime)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    @diff_settings
+    @given(
+        version=st.sampled_from([0, 1, 2, 0x7FFFFFFF, 0xFFFFFFFF]),
+        locktime=st.sampled_from([0, 1, 499999999, 500000000, 0xFFFFFFFF]),
+    )
+    def test_boundary_version_locktime_equivalence(self, version, locktime):
+        inp = TransactionInput(
+            source_txid="cc" * 32,
+            source_output_index=0,
+            unlocking_script=Script(b"\x51"),
+            sequence=0xFFFFFFFF,
+        )
+        out = TransactionOutput(satoshis=546, locking_script=Script(b"\x76"))
+        tx = Transaction(version=version, tx_inputs=[inp], tx_outputs=[out], locktime=locktime)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ---------------------------------------------------------------------------
+# Differential: preimage (BIP143)
+# ---------------------------------------------------------------------------
+
+
+BIP143_FLAGS = [
+    SIGHASH.ALL_FORKID,
+    SIGHASH.NONE_FORKID,
+    SIGHASH.SINGLE_FORKID,
+    SIGHASH.ALL_FORKID | SIGHASH.ANYONECANPAY,
+    SIGHASH.NONE_FORKID | SIGHASH.ANYONECANPAY,
+    SIGHASH.SINGLE_FORKID | SIGHASH.ANYONECANPAY,
+]
+
+OTDA_FLAGS = [
+    SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+    SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+    SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+]
+
+
+class TestPreimageBIP143Differential:
+    @diff_settings
+    @given(
+        version=uint32,
+        locktime=uint32,
+        sighash=st.sampled_from(BIP143_FLAGS),
+        locking_script=st.binary(min_size=1, max_size=512),
+        n_outputs=st.integers(min_value=1, max_value=4),
+    )
+    def test_random_bip143_preimage_equivalence(
+        self, version, locktime, sighash, locking_script, n_outputs
+    ):
+        inp = TransactionInput(
+            source_txid="dd" * 32,
+            source_output_index=0,
+            unlocking_script=Script(b""),
+            sequence=0xFFFFFFFF,
+            sighash=sighash,
+        )
+        inp.locking_script = Script(locking_script)
+        inp.satoshis = 100_000
+        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+        outputs = [
+            TransactionOutput(satoshis=1000 * (i + 1), locking_script=Script(p2pkh))
+            for i in range(n_outputs)
+        ]
+        tx = Transaction(version=version, tx_inputs=[inp], tx_outputs=outputs, locktime=locktime)
+        native, python = _toggle_preimage(tx, 0)
+        assert native == python
+
+    @diff_settings
+    @given(
+        sighash=st.sampled_from(BIP143_FLAGS),
+        n_inputs=st.integers(min_value=1, max_value=4),
+        sign_idx=st.data(),
+    )
+    def test_multi_input_bip143_equivalence(self, sighash, n_inputs, sign_idx):
+        idx = sign_idx.draw(st.integers(min_value=0, max_value=n_inputs - 1))
+        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+        inputs = []
+        for i in range(n_inputs):
+            inp = TransactionInput(
+                source_txid=f"{i:02x}" * 32,
+                source_output_index=i,
+                unlocking_script=Script(b""),
+                sequence=0xFFFFFFFF,
+                sighash=sighash,
+            )
+            inp.locking_script = Script(p2pkh)
+            inp.satoshis = 50_000 * (i + 1)
+            inputs.append(inp)
+        # SIGHASH_SINGLE requires outputs[sign_idx] to exist
+        n_outputs = max(n_inputs, idx + 1)
+        outputs = [
+            TransactionOutput(satoshis=10_000 * (i + 1), locking_script=Script(p2pkh))
+            for i in range(n_outputs)
+        ]
+        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=outputs, locktime=0)
+        native, python = _toggle_preimage(tx, idx)
+        assert native == python
+
+
+# ---------------------------------------------------------------------------
+# Differential: preimage (OTDA / Chronicle)
+# ---------------------------------------------------------------------------
+
+
+class TestPreimageOTDADifferential:
+    @diff_settings
+    @given(
+        version=uint32,
+        locktime=uint32,
+        sighash=st.sampled_from(OTDA_FLAGS),
+        locking_script=st.binary(min_size=1, max_size=512),
+        n_outputs=st.integers(min_value=1, max_value=4),
+    )
+    def test_random_otda_preimage_equivalence(
+        self, version, locktime, sighash, locking_script, n_outputs
+    ):
+        inp = TransactionInput(
+            source_txid="ee" * 32,
+            source_output_index=0,
+            unlocking_script=Script(b""),
+            sequence=0xFFFFFFFF,
+            sighash=sighash,
+        )
+        inp.locking_script = Script(locking_script)
+        inp.satoshis = 200_000
+        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+        outputs = [
+            TransactionOutput(satoshis=2000 * (i + 1), locking_script=Script(p2pkh))
+            for i in range(n_outputs)
+        ]
+        tx = Transaction(version=version, tx_inputs=[inp], tx_outputs=outputs, locktime=locktime)
+        native, python = _toggle_preimage(tx, 0)
+        assert native == python
+
+    @diff_settings
+    @given(
+        sighash=st.sampled_from(OTDA_FLAGS),
+        n_inputs=st.integers(min_value=1, max_value=4),
+        sign_idx=st.data(),
+    )
+    def test_multi_input_otda_equivalence(self, sighash, n_inputs, sign_idx):
+        idx = sign_idx.draw(st.integers(min_value=0, max_value=n_inputs - 1))
+        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+        inputs = []
+        for i in range(n_inputs):
+            inp = TransactionInput(
+                source_txid=f"{i:02x}" * 32,
+                source_output_index=i,
+                unlocking_script=Script(b""),
+                sequence=0xFFFFFFFF,
+                sighash=sighash,
+            )
+            inp.locking_script = Script(p2pkh)
+            inp.satoshis = 50_000 * (i + 1)
+            inputs.append(inp)
+        # SIGHASH_SINGLE requires outputs[sign_idx] to exist
+        n_outputs = max(n_inputs, idx + 1)
+        outputs = [
+            TransactionOutput(satoshis=10_000 * (i + 1), locking_script=Script(p2pkh))
+            for i in range(n_outputs)
+        ]
+        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=outputs, locktime=0)
+        native, python = _toggle_preimage(tx, idx)
+        assert native == python

--- a/tests/bsv/native/test_hypothesis_differential.py
+++ b/tests/bsv/native/test_hypothesis_differential.py
@@ -111,6 +111,30 @@ def _toggle_preimage(tx, idx):
     return native, python
 
 
+def _assert_multi_input_preimage_equivalence(sighash, n_inputs, sign_idx):
+    """Shared body for the BIP143/OTDA multi-input equivalence tests."""
+    idx = sign_idx.draw(st.integers(min_value=0, max_value=n_inputs - 1))
+    p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+    inputs = []
+    for i in range(n_inputs):
+        inp = TransactionInput(
+            source_txid=f"{i:02x}" * 32,
+            source_output_index=i,
+            unlocking_script=Script(b""),
+            sequence=0xFFFFFFFF,
+            sighash=sighash,
+        )
+        inp.locking_script = Script(p2pkh)
+        inp.satoshis = 50_000 * (i + 1)
+        inputs.append(inp)
+    # SIGHASH_SINGLE requires outputs[sign_idx] to exist
+    n_outputs = max(n_inputs, idx + 1)
+    outputs = [TransactionOutput(satoshis=10_000 * (i + 1), locking_script=Script(p2pkh)) for i in range(n_outputs)]
+    tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=outputs, locktime=0)
+    native, python = _toggle_preimage(tx, idx)
+    assert native == python
+
+
 # ---------------------------------------------------------------------------
 # Differential: serialize
 # ---------------------------------------------------------------------------
@@ -137,9 +161,7 @@ class TestSerializeDifferential:
         locking_script=varint_boundary_scripts,
         unlocking_script=varint_boundary_scripts,
     )
-    def test_varint_boundary_serialize_equivalence(
-        self, version, locktime, n_inputs, locking_script, unlocking_script
-    ):
+    def test_varint_boundary_serialize_equivalence(self, version, locktime, n_inputs, locking_script, unlocking_script):
         inputs = [
             TransactionInput(
                 source_txid="ab" * 32,
@@ -205,9 +227,7 @@ class TestPreimageBIP143Differential:
         locking_script=st.binary(min_size=1, max_size=512),
         n_outputs=st.integers(min_value=1, max_value=4),
     )
-    def test_random_bip143_preimage_equivalence(
-        self, version, locktime, sighash, locking_script, n_outputs
-    ):
+    def test_random_bip143_preimage_equivalence(self, version, locktime, sighash, locking_script, n_outputs):
         inp = TransactionInput(
             source_txid="dd" * 32,
             source_output_index=0,
@@ -218,10 +238,7 @@ class TestPreimageBIP143Differential:
         inp.locking_script = Script(locking_script)
         inp.satoshis = 100_000
         p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
-        outputs = [
-            TransactionOutput(satoshis=1000 * (i + 1), locking_script=Script(p2pkh))
-            for i in range(n_outputs)
-        ]
+        outputs = [TransactionOutput(satoshis=1000 * (i + 1), locking_script=Script(p2pkh)) for i in range(n_outputs)]
         tx = Transaction(version=version, tx_inputs=[inp], tx_outputs=outputs, locktime=locktime)
         native, python = _toggle_preimage(tx, 0)
         assert native == python
@@ -233,29 +250,7 @@ class TestPreimageBIP143Differential:
         sign_idx=st.data(),
     )
     def test_multi_input_bip143_equivalence(self, sighash, n_inputs, sign_idx):
-        idx = sign_idx.draw(st.integers(min_value=0, max_value=n_inputs - 1))
-        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
-        inputs = []
-        for i in range(n_inputs):
-            inp = TransactionInput(
-                source_txid=f"{i:02x}" * 32,
-                source_output_index=i,
-                unlocking_script=Script(b""),
-                sequence=0xFFFFFFFF,
-                sighash=sighash,
-            )
-            inp.locking_script = Script(p2pkh)
-            inp.satoshis = 50_000 * (i + 1)
-            inputs.append(inp)
-        # SIGHASH_SINGLE requires outputs[sign_idx] to exist
-        n_outputs = max(n_inputs, idx + 1)
-        outputs = [
-            TransactionOutput(satoshis=10_000 * (i + 1), locking_script=Script(p2pkh))
-            for i in range(n_outputs)
-        ]
-        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=outputs, locktime=0)
-        native, python = _toggle_preimage(tx, idx)
-        assert native == python
+        _assert_multi_input_preimage_equivalence(sighash, n_inputs, sign_idx)
 
 
 # ---------------------------------------------------------------------------
@@ -272,9 +267,7 @@ class TestPreimageOTDADifferential:
         locking_script=st.binary(min_size=1, max_size=512),
         n_outputs=st.integers(min_value=1, max_value=4),
     )
-    def test_random_otda_preimage_equivalence(
-        self, version, locktime, sighash, locking_script, n_outputs
-    ):
+    def test_random_otda_preimage_equivalence(self, version, locktime, sighash, locking_script, n_outputs):
         inp = TransactionInput(
             source_txid="ee" * 32,
             source_output_index=0,
@@ -285,10 +278,7 @@ class TestPreimageOTDADifferential:
         inp.locking_script = Script(locking_script)
         inp.satoshis = 200_000
         p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
-        outputs = [
-            TransactionOutput(satoshis=2000 * (i + 1), locking_script=Script(p2pkh))
-            for i in range(n_outputs)
-        ]
+        outputs = [TransactionOutput(satoshis=2000 * (i + 1), locking_script=Script(p2pkh)) for i in range(n_outputs)]
         tx = Transaction(version=version, tx_inputs=[inp], tx_outputs=outputs, locktime=locktime)
         native, python = _toggle_preimage(tx, 0)
         assert native == python
@@ -300,26 +290,4 @@ class TestPreimageOTDADifferential:
         sign_idx=st.data(),
     )
     def test_multi_input_otda_equivalence(self, sighash, n_inputs, sign_idx):
-        idx = sign_idx.draw(st.integers(min_value=0, max_value=n_inputs - 1))
-        p2pkh = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
-        inputs = []
-        for i in range(n_inputs):
-            inp = TransactionInput(
-                source_txid=f"{i:02x}" * 32,
-                source_output_index=i,
-                unlocking_script=Script(b""),
-                sequence=0xFFFFFFFF,
-                sighash=sighash,
-            )
-            inp.locking_script = Script(p2pkh)
-            inp.satoshis = 50_000 * (i + 1)
-            inputs.append(inp)
-        # SIGHASH_SINGLE requires outputs[sign_idx] to exist
-        n_outputs = max(n_inputs, idx + 1)
-        outputs = [
-            TransactionOutput(satoshis=10_000 * (i + 1), locking_script=Script(p2pkh))
-            for i in range(n_outputs)
-        ]
-        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=outputs, locktime=0)
-        native, python = _toggle_preimage(tx, idx)
-        assert native == python
+        _assert_multi_input_preimage_equivalence(sighash, n_inputs, sign_idx)

--- a/tests/bsv/native/test_tx_serialize_edge_cases.py
+++ b/tests/bsv/native/test_tx_serialize_edge_cases.py
@@ -729,9 +729,7 @@ def _build_nft_tx(image_size, sighash, *, n_outputs=2):
 class TestPreimageLargeOutput:
     """BIP143 hashOutputs and OTDA preimage buffer with multi-MB outputs."""
 
-    @pytest.mark.parametrize(
-        "megabytes", [1, 4, 20], ids=["1MB", "4MB", "20MB"]
-    )
+    @pytest.mark.parametrize("megabytes", [1, 4, 20], ids=["1MB", "4MB", "20MB"])
     @pytest.mark.parametrize(
         "sighash",
         ALL_SIGHASH_FLAGS,
@@ -786,9 +784,7 @@ class TestPreimageLargeOutputMultiInput:
     """Multi-input tx with large outputs — ensures shared hash caches and
     per-input preimage buffers are all sized correctly."""
 
-    @pytest.mark.parametrize(
-        "sighash", ALL_SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}"
-    )
+    @pytest.mark.parametrize("sighash", ALL_SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}")
     def test_multi_input_large_output(self, sighash):
         image_data = b"\xcd" * (2 * 1024 * 1024)
         op_return_script = b"\x6a" + b"\x4e" + len(image_data).to_bytes(4, "little") + image_data

--- a/tests/bsv/native/test_tx_serialize_edge_cases.py
+++ b/tests/bsv/native/test_tx_serialize_edge_cases.py
@@ -1,0 +1,902 @@
+"""
+Edge-case equivalence tests for Transaction.serialize() and the signing
+preimage path (BIP143 / OTDA) in the C extension.
+
+Covers varint boundaries, large scripts (multi-MB NFT payloads),
+satoshi boundary values, None unlocking scripts, input/output count
+boundaries, and preimage computation with large outputs/scriptCodes --
+everything the two fixed vectors in test_equivalence.py do NOT reach.
+"""
+
+import sys
+
+import pytest
+
+_bsv_native = pytest.importorskip("_bsv_native")
+
+from bsv.constants import SIGHASH
+from bsv.script.script import Script
+from bsv.transaction import Transaction, TransactionInput, TransactionOutput
+
+
+def _toggle_serialize(tx):
+    """Return (native_bytes, python_bytes) for the same Transaction."""
+    mod = sys.modules[Transaction.__module__]
+    orig = mod._USE_NATIVE_TX
+
+    mod._USE_NATIVE_TX = True
+    native = tx.serialize()
+
+    mod._USE_NATIVE_TX = False
+    python = tx.serialize()
+
+    mod._USE_NATIVE_TX = orig
+    return native, python
+
+
+_DEFAULT_TXID = "ab" * 32
+
+
+def _make_input(*, unlocking_script=None, source_txid=_DEFAULT_TXID, vout=0, seq=0xFFFFFFFF):
+    return TransactionInput(
+        source_txid=source_txid,
+        source_output_index=vout,
+        unlocking_script=unlocking_script,
+        sequence=seq,
+    )
+
+
+def _make_output(satoshis, script_bytes=b""):
+    return TransactionOutput(
+        satoshis=satoshis,
+        locking_script=Script(script_bytes),
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1. Empty / minimal transactions
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestEmptyAndMinimal:
+    def test_zero_inputs_zero_outputs(self):
+        tx = Transaction(version=1, tx_inputs=[], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_one_input_zero_outputs(self):
+        tx = Transaction(
+            version=1,
+            tx_inputs=[_make_input()],
+            tx_outputs=[],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_zero_inputs_one_output(self):
+        tx = Transaction(
+            version=1,
+            tx_inputs=[],
+            tx_outputs=[_make_output(1000, b"\x76\xa9")],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 2. None / empty unlocking_script (the if-else branch in serialize())
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestUnlockingScriptNone:
+    def test_none_unlocking_script(self):
+        inp = _make_input(unlocking_script=None)
+        assert inp.unlocking_script is None
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_empty_unlocking_script(self):
+        inp = _make_input(unlocking_script=Script(b""))
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_none_vs_empty_produce_same_bytes(self):
+        inp_none = _make_input(unlocking_script=None)
+        inp_empty = _make_input(unlocking_script=Script(b""))
+        tx_none = Transaction(version=1, tx_inputs=[inp_none], tx_outputs=[], locktime=0)
+        tx_empty = Transaction(version=1, tx_inputs=[inp_empty], tx_outputs=[], locktime=0)
+        n1, p1 = _toggle_serialize(tx_none)
+        n2, p2 = _toggle_serialize(tx_empty)
+        assert n1 == n2 == p1 == p2
+
+    def test_mixed_none_and_present(self):
+        tx = Transaction(
+            version=1,
+            tx_inputs=[
+                _make_input(unlocking_script=None),
+                _make_input(unlocking_script=Script(b"\x00\x51")),
+                _make_input(unlocking_script=None),
+            ],
+            tx_outputs=[],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 3. Varint boundaries for SCRIPT LENGTH
+#    < 0xFD (1-byte), == 0xFD (3-byte), > 0xFFFF (5-byte)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVarintScriptLength:
+    @pytest.mark.parametrize(
+        "size,label",
+        [
+            (0, "empty"),
+            (1, "1-byte"),
+            (75, "max-direct-push"),
+            (252, "max-1byte-varint"),
+            (253, "first-3byte-varint-0xFD"),
+            (254, "0xFD+1"),
+            (0xFF, "0xFF"),
+            (0x100, "0x100"),
+            (0xFFFE, "0xFFFF-1"),
+            (0xFFFF, "max-3byte-varint"),
+            (0x10000, "first-5byte-varint-0x10000"),
+        ],
+        ids=lambda x: x if isinstance(x, str) else None,
+    )
+    def test_locking_script_varint_boundary(self, size, label):
+        script_bytes = bytes(range(256)) * (size // 256) + bytes(range(size % 256))
+        assert len(script_bytes) == size
+        tx = Transaction(
+            version=1,
+            tx_inputs=[],
+            tx_outputs=[_make_output(500, script_bytes)],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python, f"mismatch at script size {size} ({label})"
+
+    @pytest.mark.parametrize(
+        "size",
+        [252, 253, 0xFFFF, 0x10000],
+        ids=["252", "253", "0xFFFF", "0x10000"],
+    )
+    def test_unlocking_script_varint_boundary(self, size):
+        script_bytes = b"\x00" * size
+        inp = _make_input(unlocking_script=Script(script_bytes))
+        tx = Transaction(
+            version=1,
+            tx_inputs=[inp],
+            tx_outputs=[],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python, f"mismatch at unlocking script size {size}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 4. Large scripts -- NFT images (multi-MB)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestLargeScripts:
+    @pytest.mark.parametrize(
+        "megabytes",
+        [1, 4, 8, 20],
+        ids=["1MB", "4MB", "8MB", "20MB"],
+    )
+    def test_large_locking_script_nft_image(self, megabytes):
+        size = megabytes * 1024 * 1024
+        script_bytes = b"\xab" * size
+        tx = Transaction(
+            version=1,
+            tx_inputs=[_make_input(unlocking_script=Script(b"\x51"))],
+            tx_outputs=[_make_output(0, script_bytes)],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+        assert len(native) > size
+
+    def test_large_unlocking_script(self):
+        size = 2 * 1024 * 1024
+        script_bytes = b"\xcd" * size
+        inp = _make_input(unlocking_script=Script(script_bytes))
+        tx = Transaction(
+            version=1,
+            tx_inputs=[inp],
+            tx_outputs=[_make_output(1000)],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_multiple_large_outputs(self):
+        outputs = [_make_output(0, b"\xef" * (512 * 1024)) for _ in range(4)]
+        tx = Transaction(
+            version=1,
+            tx_inputs=[_make_input()],
+            tx_outputs=outputs,
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+        assert len(native) > 2 * 1024 * 1024
+
+    def test_roundtrip_large_script(self):
+        size = 1 * 1024 * 1024
+        script_bytes = bytes(range(256)) * (size // 256)
+        tx = Transaction(
+            version=1,
+            tx_inputs=[_make_input(unlocking_script=Script(b"\x00"))],
+            tx_outputs=[_make_output(42, script_bytes)],
+            locktime=0,
+        )
+        native, _ = _toggle_serialize(tx)
+        tx2 = Transaction.from_hex(native)
+        assert tx2.outputs[0].locking_script.serialize() == script_bytes
+        assert tx2.serialize() == native
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 5. Varint boundaries for INPUT/OUTPUT COUNT
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVarintInputOutputCount:
+    @pytest.mark.parametrize(
+        "count",
+        [1, 252, 253, 300],
+        ids=["1", "252-max1byte", "253-first3byte", "300"],
+    )
+    def test_input_count_boundary(self, count):
+        inputs = [_make_input() for _ in range(count)]
+        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    @pytest.mark.parametrize(
+        "count",
+        [1, 252, 253, 300],
+        ids=["1", "252-max1byte", "253-first3byte", "300"],
+    )
+    def test_output_count_boundary(self, count):
+        outputs = [_make_output(i, b"\x76") for i in range(count)]
+        tx = Transaction(version=1, tx_inputs=[], tx_outputs=outputs, locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 6. Satoshi boundary values
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestSatoshiBoundaries:
+    @pytest.mark.parametrize(
+        "satoshis,label",
+        [
+            (0, "zero"),
+            (1, "dust"),
+            (0xFF, "1byte-max"),
+            (0xFFFF, "2byte-max"),
+            (0xFFFFFF, "3byte-max"),
+            (0xFFFFFFFF, "uint32-max"),
+            (0xFFFFFFFFFF, "5byte-max"),
+            (21_000_000 * 100_000_000, "max-supply"),
+            (0xFFFFFFFFFFFFFFFF, "uint64-max"),
+        ],
+        ids=lambda x: x if isinstance(x, str) else None,
+    )
+    def test_satoshi_value(self, satoshis, label):
+        tx = Transaction(
+            version=1,
+            tx_inputs=[],
+            tx_outputs=[_make_output(satoshis, b"\x76\xa9")],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python, f"mismatch at satoshis={satoshis} ({label})"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 7. Version / locktime edge values
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVersionAndLocktime:
+    @pytest.mark.parametrize("version", [0, 1, 2, 0xFF, 0xFFFF, 0xFFFFFFFF])
+    def test_version_values(self, version):
+        tx = Transaction(version=version, tx_inputs=[], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    @pytest.mark.parametrize(
+        "locktime",
+        [0, 1, 499_999_999, 500_000_000, 0xFFFFFFFE, 0xFFFFFFFF],
+        ids=["zero", "one", "max-block-height", "min-timestamp", "max-1", "max-uint32"],
+    )
+    def test_locktime_values(self, locktime):
+        tx = Transaction(version=1, tx_inputs=[], tx_outputs=[], locktime=locktime)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 8. Input field edge values
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestInputFieldEdges:
+    def test_source_output_index_max(self):
+        inp = _make_input(vout=0xFFFFFFFF)
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_sequence_zero(self):
+        inp = _make_input(seq=0)
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_varied_source_txids(self):
+        txids = [
+            "00" * 32,
+            "ff" * 32,
+            "01" + "00" * 31,
+            "00" * 31 + "01",
+        ]
+        inputs = [_make_input(source_txid=txid) for txid in txids]
+        tx = Transaction(version=1, tx_inputs=inputs, tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 9. Full roundtrip: serialize → from_hex → serialize must be idempotent
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestRoundTrip:
+    def test_complex_tx_roundtrip(self):
+        tx = Transaction(
+            version=2,
+            tx_inputs=[
+                _make_input(unlocking_script=Script(b"\x00" * 200)),
+                _make_input(unlocking_script=None),
+                _make_input(unlocking_script=Script(b"\x51\x52\x93")),
+            ],
+            tx_outputs=[
+                _make_output(0, b""),
+                _make_output(21_000_000 * 100_000_000, b"\x76\xa9" + b"\x00" * 20 + b"\x88\xac"),
+                _make_output(1, b"\x6a" + b"\x04" + b"\xde\xad\xbe\xef"),
+            ],
+            locktime=500_000,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+        tx2 = Transaction.from_hex(native)
+        assert tx2.serialize() == native
+
+    def test_nft_like_tx_roundtrip(self):
+        image_data = bytes(range(256)) * 4096  # ~1 MB
+        op_return_script = b"\x6a" + b"\x4e" + len(image_data).to_bytes(4, "little") + image_data
+
+        tx = Transaction(
+            version=1,
+            tx_inputs=[_make_input(unlocking_script=Script(b"\x00" * 107))],
+            tx_outputs=[
+                _make_output(0, op_return_script),
+                _make_output(546, b"\x76\xa9" + b"\x14" + b"\xaa" * 20 + b"\x88\xac"),
+            ],
+            locktime=0,
+        )
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+        tx2 = Transaction.from_hex(native)
+        assert tx2.outputs[0].locking_script.serialize() == op_return_script
+        assert tx2.serialize() == native
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 10. Stress: many inputs × many outputs with varied scripts
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestStressCombination:
+    def test_many_inputs_many_outputs_varied(self):
+        inputs = []
+        for i in range(50):
+            script_len = (i * 37) % 300
+            script = Script(bytes([i & 0xFF]) * script_len) if script_len > 0 else None
+            inputs.append(
+                _make_input(
+                    unlocking_script=script,
+                    source_txid=f"{i:064x}",
+                    vout=i,
+                    seq=0xFFFFFFFF - i,
+                )
+            )
+
+        outputs = []
+        for i in range(50):
+            script_len = (i * 53) % 500
+            outputs.append(
+                _make_output(
+                    satoshis=i * 100_000,
+                    script_bytes=bytes([(i + j) & 0xFF for j in range(script_len)]),
+                )
+            )
+
+        tx = Transaction(version=2, tx_inputs=inputs, tx_outputs=outputs, locktime=12345)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 11. Error parity: C and Python must reject invalid inputs identically
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestVersionLocktimeRejection:
+    """version/locktime out-of-range must raise OverflowError on BOTH paths."""
+
+    @pytest.mark.parametrize(
+        "version,locktime,label",
+        [
+            (-1, 0, "negative-version"),
+            (2**32, 0, "version-overflow"),
+            (2**33, 0, "version-large-overflow"),
+            (0, -1, "negative-locktime"),
+            (0, 2**32, "locktime-overflow"),
+            (0, 2**33, "locktime-large-overflow"),
+        ],
+        ids=lambda x: x if isinstance(x, str) else None,
+    )
+    def test_overflow_raises_on_both_paths(self, version, locktime, label):
+        mod = sys.modules[Transaction.__module__]
+        orig = mod._USE_NATIVE_TX
+
+        tx = Transaction(version=version, tx_inputs=[], tx_outputs=[], locktime=locktime)
+
+        # C path
+        mod._USE_NATIVE_TX = True
+        try:
+            with pytest.raises(OverflowError):
+                tx.serialize()
+        finally:
+            mod._USE_NATIVE_TX = orig
+
+        # Python path
+        mod._USE_NATIVE_TX = False
+        try:
+            with pytest.raises(OverflowError):
+                tx.serialize()
+        finally:
+            mod._USE_NATIVE_TX = orig
+
+    @pytest.mark.parametrize(
+        "version,locktime",
+        [(None, 0), (1.5, 0), ("1", 0), (0, None), (0, 1.5)],
+        ids=["version-None", "version-float", "version-str", "locktime-None", "locktime-float"],
+    )
+    def test_type_error_on_native_path(self, version, locktime):
+        tx = Transaction(version=version, tx_inputs=[], tx_outputs=[], locktime=locktime)
+        mod = sys.modules[Transaction.__module__]
+        orig = mod._USE_NATIVE_TX
+        mod._USE_NATIVE_TX = True
+        try:
+            with pytest.raises(TypeError):
+                tx.serialize()
+        finally:
+            mod._USE_NATIVE_TX = orig
+
+
+class TestScriptTypeRejection:
+    """Non-bytes script types must be rejected, not silently treated as empty."""
+
+    @pytest.mark.parametrize(
+        "bad_script",
+        [bytearray(b"\x51"), memoryview(b"\x51"), "51", 42],
+        ids=["bytearray", "memoryview", "str", "int"],
+    )
+    def test_unlocking_script_rejects_non_bytes(self, bad_script):
+        inp_dict = {
+            "source_txid": "aa" * 32,
+            "source_output_index": 0,
+            "unlocking_script": bad_script,
+            "sequence": 0xFFFFFFFF,
+        }
+        with pytest.raises(TypeError, match="unlocking_script"):
+            _bsv_native.tx_to_bytes(1, [inp_dict], [], 0)
+
+    @pytest.mark.parametrize(
+        "bad_script",
+        [None, bytearray(b"\x76"), "76a9", 0],
+        ids=["None", "bytearray", "str", "int"],
+    )
+    def test_locking_script_rejects_non_bytes(self, bad_script):
+        out_dict = {"satoshis": 1000, "locking_script": bad_script}
+        with pytest.raises(TypeError, match="locking_script"):
+            _bsv_native.tx_to_bytes(1, [], [out_dict], 0)
+
+
+class TestSourceTxidRejection:
+    """source_txid edge cases: C and Python paths must agree."""
+
+    INVALID_TXIDS = [
+        ("aa" * 31, "short-62"),
+        ("aa" * 33, "long-66"),
+        ("gg" * 32, "non-hex"),
+        ("", "empty"),
+        ("aa " * 32, "with-spaces"),
+    ]
+
+    VALID_TXIDS = [
+        ("AA" * 32, "uppercase"),
+        ("aa" * 32, "normal"),
+    ]
+
+    @pytest.mark.parametrize(
+        "txid,label",
+        INVALID_TXIDS,
+        ids=[t[1] for t in INVALID_TXIDS],
+    )
+    def test_invalid_txid_rejected_on_both_paths(self, txid, label):
+        """Invalid txids must be rejected on both C and Python paths."""
+        # C path (via _bsv_native directly)
+        inp_dict = {
+            "source_txid": txid,
+            "source_output_index": 0,
+            "unlocking_script": b"",
+            "sequence": 0xFFFFFFFF,
+        }
+        with pytest.raises((TypeError, ValueError)):
+            _bsv_native.tx_to_bytes(1, [inp_dict], [], 0)
+
+        # Python path (via Transaction.serialize fallback)
+        mod = sys.modules[Transaction.__module__]
+        orig = mod._USE_NATIVE_TX
+        mod._USE_NATIVE_TX = False
+        try:
+            inp = _make_input(source_txid=txid)
+            tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+            with pytest.raises(ValueError):
+                tx.serialize()
+        finally:
+            mod._USE_NATIVE_TX = orig
+
+    def test_none_txid_rejected_on_c_path(self):
+        inp_dict = {
+            "source_txid": None,
+            "source_output_index": 0,
+            "unlocking_script": b"",
+            "sequence": 0xFFFFFFFF,
+        }
+        with pytest.raises((TypeError, ValueError)):
+            _bsv_native.tx_to_bytes(1, [inp_dict], [], 0)
+
+    @pytest.mark.parametrize(
+        "txid,label",
+        VALID_TXIDS,
+        ids=[t[1] for t in VALID_TXIDS],
+    )
+    def test_valid_txid_accepted_on_both_paths(self, txid, label):
+        """Valid txids produce identical bytes on both paths."""
+        inp = _make_input(source_txid=txid)
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+
+class TestSatoshisRejection:
+    """satoshis out-of-range in the C path."""
+
+    @pytest.mark.parametrize(
+        "satoshis",
+        [-1, 2**64, -(2**63)],
+        ids=["negative", "uint64-overflow", "large-negative"],
+    )
+    def test_satoshis_overflow(self, satoshis):
+        out_dict = {"satoshis": satoshis, "locking_script": b""}
+        with pytest.raises((OverflowError, ValueError)):
+            _bsv_native.tx_to_bytes(1, [], [out_dict], 0)
+
+
+class TestMissingKeys:
+    """Missing required dict keys in the C path."""
+
+    def test_missing_source_txid(self):
+        inp = {"source_output_index": 0, "unlocking_script": b"", "sequence": 0xFFFFFFFF}
+        with pytest.raises((TypeError, KeyError)):
+            _bsv_native.tx_to_bytes(1, [inp], [], 0)
+
+    def test_missing_sequence(self):
+        inp = {"source_txid": "aa" * 32, "source_output_index": 0, "unlocking_script": b""}
+        with pytest.raises(KeyError):
+            _bsv_native.tx_to_bytes(1, [inp], [], 0)
+
+    def test_missing_satoshis(self):
+        out = {"locking_script": b""}
+        with pytest.raises(KeyError):
+            _bsv_native.tx_to_bytes(1, [], [out], 0)
+
+    def test_missing_locking_script(self):
+        out = {"satoshis": 1000}
+        with pytest.raises(TypeError):
+            _bsv_native.tx_to_bytes(1, [], [out], 0)
+
+    def test_non_dict_input(self):
+        with pytest.raises(TypeError):
+            _bsv_native.tx_to_bytes(1, ["not a dict"], [], 0)
+
+    def test_non_dict_output(self):
+        with pytest.raises(TypeError):
+            _bsv_native.tx_to_bytes(1, [], ["not a dict"], 0)
+
+    def test_non_list_inputs(self):
+        with pytest.raises(TypeError):
+            _bsv_native.tx_to_bytes(1, "not a list", [], 0)
+
+    def test_non_list_outputs(self):
+        with pytest.raises(TypeError):
+            _bsv_native.tx_to_bytes(1, [], "not a list", 0)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 12. Signing preimage with large scripts (BIP143 + OTDA)
+#     Verifies that hashOutputs / OTDA preimage buffers handle multi-MB
+#     outputs (NFT images) and large scriptCodes correctly.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _toggle_preimage(tx, input_index):
+    """Return (native_preimage, python_preimage) for a single input."""
+    import bsv.transaction_preimage as tp_mod
+
+    orig = tp_mod._USE_NATIVE
+    tp_mod._USE_NATIVE = True
+    try:
+        native = tx.preimage(input_index)
+    finally:
+        tp_mod._USE_NATIVE = orig
+
+    tp_mod._USE_NATIVE = False
+    try:
+        python = tx.preimage(input_index)
+    finally:
+        tp_mod._USE_NATIVE = orig
+
+    return native, python
+
+
+P2PKH_SCRIPT = bytes.fromhex("76a914c0a3c167a28cabb9fbb495affa0761e6e74ac60d88ac")
+
+BIP143_SIGHASH_FLAGS = [
+    SIGHASH.ALL_FORKID,
+    SIGHASH.NONE_FORKID,
+    SIGHASH.SINGLE_FORKID,
+    SIGHASH.ALL_FORKID | SIGHASH.ANYONECANPAY,
+    SIGHASH.NONE_FORKID | SIGHASH.ANYONECANPAY,
+    SIGHASH.SINGLE_FORKID | SIGHASH.ANYONECANPAY,
+]
+
+OTDA_SIGHASH_FLAGS = [
+    SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE,
+    SIGHASH.ALL_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+    SIGHASH.NONE_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+    SIGHASH.SINGLE_FORKID | SIGHASH.CHRONICLE | SIGHASH.ANYONECANPAY,
+]
+
+ALL_SIGHASH_FLAGS = BIP143_SIGHASH_FLAGS + OTDA_SIGHASH_FLAGS
+
+
+def _build_nft_tx(image_size, sighash, *, n_outputs=2):
+    """Build a transaction with a large OP_RETURN output (NFT image)."""
+    image_data = b"\xab" * image_size
+    op_return_script = b"\x6a" + b"\x4e" + len(image_data).to_bytes(4, "little") + image_data
+
+    outputs = [_make_output(0, op_return_script)]
+    for i in range(1, n_outputs):
+        outputs.append(_make_output(546 * i, P2PKH_SCRIPT))
+
+    inp = TransactionInput(
+        source_txid="aa" * 32,
+        source_output_index=0,
+        unlocking_script=None,
+        sequence=0xFFFFFFFF,
+    )
+    inp.locking_script = Script(P2PKH_SCRIPT)
+    inp.satoshis = 100_000
+    inp.sighash = sighash
+
+    return Transaction(version=1, tx_inputs=[inp], tx_outputs=outputs, locktime=0)
+
+
+class TestPreimageLargeOutput:
+    """BIP143 hashOutputs and OTDA preimage buffer with multi-MB outputs."""
+
+    @pytest.mark.parametrize(
+        "megabytes", [1, 4, 20], ids=["1MB", "4MB", "20MB"]
+    )
+    @pytest.mark.parametrize(
+        "sighash",
+        ALL_SIGHASH_FLAGS,
+        ids=lambda s: f"0x{int(s):02x}",
+    )
+    def test_preimage_large_nft_output(self, megabytes, sighash):
+        size = megabytes * 1024 * 1024
+        tx = _build_nft_tx(size, sighash)
+        native, python = _toggle_preimage(tx, 0)
+        assert native == python
+        assert len(native) > 0
+
+
+class TestPreimageLargeScriptCode:
+    """BIP143 scriptCode / OTDA scriptSig with a large locking_script on the
+    signing input (e.g. spending from a complex smart contract)."""
+
+    @pytest.mark.parametrize(
+        "script_size",
+        [253, 0x10000, 1 * 1024 * 1024],
+        ids=["253B-varint-boundary", "64KB", "1MB"],
+    )
+    @pytest.mark.parametrize(
+        "sighash",
+        ALL_SIGHASH_FLAGS,
+        ids=lambda s: f"0x{int(s):02x}",
+    )
+    def test_preimage_large_input_locking_script(self, script_size, sighash):
+        large_locking = b"\x00" * script_size
+        inp = TransactionInput(
+            source_txid="bb" * 32,
+            source_output_index=0,
+            unlocking_script=None,
+            sequence=0xFFFFFFFF,
+        )
+        inp.locking_script = Script(large_locking)
+        inp.satoshis = 50_000
+        inp.sighash = sighash
+
+        tx = Transaction(
+            version=1,
+            tx_inputs=[inp],
+            tx_outputs=[_make_output(1000, P2PKH_SCRIPT)],
+            locktime=0,
+        )
+        native, python = _toggle_preimage(tx, 0)
+        assert native == python
+        assert len(native) > 0
+
+
+class TestPreimageLargeOutputMultiInput:
+    """Multi-input tx with large outputs — ensures shared hash caches and
+    per-input preimage buffers are all sized correctly."""
+
+    @pytest.mark.parametrize(
+        "sighash", ALL_SIGHASH_FLAGS, ids=lambda s: f"0x{int(s):02x}"
+    )
+    def test_multi_input_large_output(self, sighash):
+        image_data = b"\xcd" * (2 * 1024 * 1024)
+        op_return_script = b"\x6a" + b"\x4e" + len(image_data).to_bytes(4, "little") + image_data
+
+        inputs = []
+        for i in range(3):
+            inp = TransactionInput(
+                source_txid=f"{i:064x}",
+                source_output_index=i,
+                unlocking_script=None,
+                sequence=0xFFFFFFFF,
+            )
+            inp.locking_script = Script(P2PKH_SCRIPT)
+            inp.satoshis = 100_000
+            inp.sighash = sighash
+            inputs.append(inp)
+
+        tx = Transaction(
+            version=1,
+            tx_inputs=inputs,
+            tx_outputs=[
+                _make_output(0, op_return_script),
+                _make_output(546, P2PKH_SCRIPT),
+                _make_output(546, P2PKH_SCRIPT),
+            ],
+            locktime=0,
+        )
+
+        for idx in range(3):
+            native, python = _toggle_preimage(tx, idx)
+            assert native == python, f"preimage mismatch at input {idx}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 13. Subclass fallback: native path is only used for exact types.
+#     Subclasses of TransactionInput / TransactionOutput must trigger
+#     the Python fallback so serialize() overrides are honoured.
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class _CustomInput(TransactionInput):
+    """Subclass that appends a marker byte to the serialized output."""
+
+    MARKER = b"\xfe"
+
+    def serialize(self) -> bytes:
+        return super().serialize() + self.MARKER
+
+
+class _CustomOutput(TransactionOutput):
+    """Subclass that appends a marker byte to the serialized output."""
+
+    MARKER = b"\xfd"
+
+    def serialize(self) -> bytes:
+        return super().serialize() + self.MARKER
+
+
+class TestSubclassFallback:
+    """Subclassed inputs/outputs must fall back to the Python path."""
+
+    def test_standard_types_use_native(self):
+        """Exact TransactionInput/TransactionOutput should use native."""
+        inp = _make_input()
+        out = _make_output(1000, P2PKH_SCRIPT)
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[out], locktime=0)
+        native, python = _toggle_serialize(tx)
+        assert native == python
+
+    def test_subclass_input_triggers_fallback(self):
+        """A subclassed TransactionInput must call its serialize() override."""
+        custom_inp = _CustomInput(
+            source_txid="ab" * 32,
+            source_output_index=0,
+            unlocking_script=Script(b"\x00"),
+            sequence=0xFFFFFFFF,
+        )
+        out = _make_output(1000, P2PKH_SCRIPT)
+        tx = Transaction(version=1, tx_inputs=[custom_inp], tx_outputs=[out], locktime=0)
+        result = tx.serialize()
+        assert result.count(_CustomInput.MARKER) == 1
+
+    def test_subclass_output_triggers_fallback(self):
+        """A subclassed TransactionOutput must call its serialize() override."""
+        inp = _make_input()
+        custom_out = _CustomOutput(
+            satoshis=1000,
+            locking_script=Script(P2PKH_SCRIPT),
+        )
+        tx = Transaction(version=1, tx_inputs=[inp], tx_outputs=[custom_out], locktime=0)
+        result = tx.serialize()
+        assert result.count(_CustomOutput.MARKER) == 1
+
+    def test_mixed_standard_and_subclass(self):
+        """One subclass among standard types is enough to trigger fallback."""
+        standard_inp = _make_input()
+        custom_inp = _CustomInput(
+            source_txid="cd" * 32,
+            source_output_index=1,
+            unlocking_script=Script(b"\x51"),
+            sequence=0xFFFFFFFF,
+        )
+        out = _make_output(2000, P2PKH_SCRIPT)
+        tx = Transaction(
+            version=1,
+            tx_inputs=[standard_inp, custom_inp],
+            tx_outputs=[out],
+            locktime=0,
+        )
+        result = tx.serialize()
+        assert _CustomInput.MARKER in result


### PR DESCRIPTION
## Summary

- `get_varint_size` in `SatoshisPerKilobyte.compute_fee` used `> 253` / `> 2**16` / `> 2**32`, underestimating varint size by 2–4 bytes when a script length landed exactly on a Bitcoin varint boundary (253, 65536, 4294967296). Fixed to `> 0xFC` / `> 0xFFFF` / `> 0xFFFFFFFF`, aligning with the canonical encoder in `binary.py` and the SV Node / Teranode / Go SDK implementations.
- Fixed pre-existing test failures in `fee_models_test_coverage.py` (wrong constructor kwarg `rate=` → `value=`, and `int` passed instead of `Transaction` to `compute_fee`).
- Added parametrized regression tests verifying varint size consistency against `unsigned_to_varint` at all boundaries.

### Cross-SDK status

| SDK | Boundary | Status |
|-----|----------|--------|
| SV Node (`serialize.h`) | `< 253` / `<= uint16_max` / `<= uint32_max` | ✅ Correct |
| Teranode (`util/varint.go`) | `< 0xfd` / `<= 0xffff` / `<= 0xffffffff` | ✅ Correct |
| Go SDK (`util/varint.go`) | `< 253` / `< 65536` / `< 4294967296` | ✅ Correct |
| py-sdk `binary.py` (encoder) | `<= 0xFC` / `<= 0xFFFF` / `<= 0xFFFFFFFF` | ✅ Correct |
| **py-sdk `SatoshisPerKilobyte`** | `> 253` / `> 2**16` / `> 2**32` | ❌ → ✅ **This PR** |
| TS SDK `SatoshisPerKilobyte.ts` | `> 253` / `> 2**16` / `> 2**32` | ❌ Same bug (ts-stack monorepo, unfixed as of 2026-07-27) |

## Test plan

- [x] `pytest tests/bsv/fee_model_test_coverage.py -v` — all 15 tests pass including 4 new boundary regression tests
- [x] `pytest tests/bsv/fee_models_test_coverage.py -v` — all 7 tests pass (previously 4 failed)
- [ ] Verify no regressions in full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)