### PR TITLE
fix(script): bound OP_SUBSTR against out-of-bounds reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Security
+
+- **`OP_SUBSTR` out-of-bounds read in the C extension** — the offset and length both come off the stack, and the range check compared `start + length` against the operand size with both values held as `long long`. An offset near `LLONG_MAX` overflowed that sum to a negative value, which passed the bound, and the native VM then copied `length` bytes from `data + start`. A ~20-byte locking script was enough: small lengths returned live process memory onto the stack, where `OP_EQUAL` can read it back a byte at a time, and larger ones segfaulted the process. The check now bounds the offset against the operand and the length against the bytes remaining, so no addition can overflow, matching the TS and Go SDKs. The pure-Python VM was not memory-unsafe but shared the weaker bound, so the two paths disagreed on these inputs.
+
+### Fixed
+
+- **`OP_SUBSTR` accepted an offset equal to the operand length** — with a zero length this returned an empty result where the TS and Go SDKs both require `offset < size` and reject. Fixed on both VM paths as part of the range check above.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -3957,17 +3957,24 @@ static int vm_step(VMState *st) {
         long long length = PyLong_AsLongLong(lobj);
         long long start  = PyLong_AsLongLong(sobj);
         Py_DECREF(lobj); Py_DECREF(sobj);
+        /* A value too wide for long long cannot address this buffer; without
+           this the failed conversion leaves -1 behind with the error still set. */
+        int too_wide = PyErr_Occurred() != NULL;
+        if (too_wide) PyErr_Clear();
         if (dat.len == 0) {
             se_free(&dat);
             vm_error(st, "OP_SUBSTR: source string is empty.");
             return -1;
         }
-        if (length < 0) {
+        if (!too_wide && length < 0) {
             se_free(&dat);
             vm_error(st, "OP_SUBSTR: length is negative.");
             return -1;
         }
-        if (start < 0 || start + length > dat.len) {
+        /* Compare against the remaining bytes rather than start + length: both
+           are attacker-supplied, and their sum overflows to a negative value
+           that slips past the bound. Mirrors the TS/Go range check. */
+        if (too_wide || start < 0 || start >= dat.len || length > dat.len - start) {
             se_free(&dat);
             vm_error(st, "OP_SUBSTR: specified range exceeds source string.");
             return -1;

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -783,7 +783,9 @@ class Spend:
                     self.script_evaluation_error("OP_SUBSTR: source string is empty.")
                 if length < 0:
                     self.script_evaluation_error("OP_SUBSTR: length is negative.")
-                if start < 0 or start + length > len(data):
+                # Bound against the remaining bytes, matching the TS/Go range
+                # check; start == len(data) is out of range even for length 0.
+                if start < 0 or start >= len(data) or length > len(data) - start:
                     self.script_evaluation_error("OP_SUBSTR: specified range exceeds source string.")
                 self.stack.append(data[start : start + length])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_substr_bounds.py
+++ b/tests/bsv/script/test_substr_bounds.py
@@ -1,0 +1,97 @@
+"""Range checking for OP_SUBSTR.
+
+The offset and length both come off the stack, so the range check has to hold
+for hostile values, not just plausible ones. It mirrors the TS SDK
+(`Spend.ts`) and Go SDK (`interpreter/operations.go`): the offset must fall
+inside the operand, and the length must fit in what remains.
+"""
+
+import pytest
+
+from bsv.script.spend import _USE_NATIVE_VM
+
+from .conftest import make_spend
+
+LLONG_MAX = 0x7FFFFFFFFFFFFFFF
+
+
+def _num_asm(n: int) -> str:
+    if n == 0:
+        return "OP_0"
+    out = bytearray()
+    v = n
+    while v:
+        out.append(v & 0xFF)
+        v >>= 8
+    if out[-1] & 0x80:
+        out.append(0)
+    return bytes(out).hex()
+
+
+def _run_both_paths(asm: str, tx_version: int = 2) -> list:
+    """Return each VM path's result so native and Python stay in lockstep."""
+    results = [make_spend(asm, tx_version=tx_version)._validate_python()]
+    if _USE_NATIVE_VM:
+        results.append(make_spend(asm, tx_version=tx_version)._validate_native())
+    return results
+
+
+def _expect_rejected(asm: str, tx_version: int = 2) -> None:
+    with pytest.raises(RuntimeError, match="OP_SUBSTR"):
+        make_spend(asm, tx_version=tx_version)._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = make_spend(asm, tx_version=tx_version)
+        with pytest.raises(RuntimeError, match="OP_SUBSTR"):
+            native_spend._validate_native()
+
+
+@pytest.mark.parametrize(
+    "data,start,length,expected",
+    [
+        ("aabbcc", 0, 3, "aabbcc"),
+        ("aabbcc", 1, 2, "bbcc"),
+        ("aabbcc", 2, 1, "cc"),
+        ("aabbcc", 0, 0, "OP_0"),
+        ("aabbcc", 2, 0, "OP_0"),
+    ],
+)
+def test_substr_extracts_expected_range(data, start, length, expected):
+    asm = f"{data} {_num_asm(start)} {_num_asm(length)} OP_SUBSTR {expected} OP_EQUAL"
+    assert all(_run_both_paths(asm))
+
+
+@pytest.mark.parametrize("length", [1, 16, 256 * 1024 * 1024])
+def test_offset_near_llong_max_is_rejected(length):
+    # Regression: `start + length` was compared against the operand size with
+    # both values as long long, so an offset near LLONG_MAX overflowed to a
+    # negative sum and slipped past the bound. The native VM then read from
+    # `data + start` -- an out-of-bounds read that returned live process bytes
+    # onto the stack for small lengths and segfaulted for large ones.
+    _expect_rejected(f"aa {_num_asm(LLONG_MAX)} {_num_asm(length)} OP_SUBSTR OP_TRUE")
+
+
+def test_offset_too_wide_for_int64_is_rejected():
+    # Wider than long long: the conversion fails rather than overflowing.
+    _expect_rejected(f"aa {_num_asm(1 << 100)} OP_1 OP_SUBSTR OP_TRUE")
+
+
+def test_offset_at_operand_length_is_rejected():
+    # TS/Go both require offset < size, even when nothing would be copied.
+    _expect_rejected("aa OP_1 OP_0 OP_SUBSTR OP_TRUE")
+
+
+def test_length_past_end_is_rejected():
+    _expect_rejected("aabbcc OP_1 OP_3 OP_SUBSTR OP_TRUE")
+
+
+def test_negative_offset_is_rejected():
+    # 0x81 is script-number -1
+    _expect_rejected("aabbcc 81 OP_1 OP_SUBSTR OP_TRUE")
+
+
+def test_negative_length_is_rejected():
+    _expect_rejected("aabbcc OP_1 81 OP_SUBSTR OP_TRUE")
+
+
+def test_empty_operand_is_rejected():
+    _expect_rejected("OP_0 OP_0 OP_0 OP_SUBSTR OP_TRUE")


### PR DESCRIPTION
## What

`OP_SUBSTR`'s offset and length both come off the stack, and the range check in
the C extension compared `start + length` against the operand size with both
values held as `long long`:

```c
if (start < 0 || start + length > dat.len) { /* reject */ }
```

An offset near `LLONG_MAX` overflows that sum to a negative value, which passes
the bound. The native VM then runs `vms_push(&st->stack, dat.data + start, length)`
— copying `length` bytes from a wild pointer.

A ~20-byte locking script reaches it. Verified on this branch's parent:

| script | result |
|---|---|
| `aa <LLONG_MAX> 1 OP_SUBSTR` | returns — 1 byte read out of bounds, pushed to the stack |
| `aa <LLONG_MAX> 16 OP_SUBSTR` | returns — 16 bytes read out of bounds |
| `aa <LLONG_MAX> 268435456 OP_SUBSTR` | **SIGSEGV** (exit 139) |

The read bytes land on the stack, so `OP_EQUAL` can probe process memory a byte
at a time. Running the new tests against the unfixed extension crashes pytest
itself.

This ships in released 2.3.3 — the code is unchanged since the opcode was added.

## Fix

Bound the offset against the operand and the length against the bytes
remaining, so no addition can overflow:

```c
if (too_wide || start < 0 || start >= dat.len || length > dat.len - start)
```

That is the same shape the TS SDK (`Spend.ts`) and Go SDK
(`interpreter/operations.go`) use, which also closes a second divergence: an
offset *equal to* the operand length was accepted with a zero length, where
both references require `offset < size`.

A value too wide for `long long` now fails the range check rather than silently
becoming `-1` with the conversion error left pending — `PyLong_AsLongLong`'s
result was previously unchecked here, though its siblings in `OP_LEFT`,
`OP_RIGHT` and `OP_SPLIT` do check.

The pure-Python VM was never memory-unsafe (Python integers do not overflow)
but shared the weaker bound, so the two paths disagreed on these inputs. Both
are fixed together.

## Testing

New `tests/bsv/script/test_substr_bounds.py`, every case run through **both**
VM paths:

- 5 extraction vectors covering the normal ranges and the zero-length cases
- the overflow regression at three lengths, including the one that segfaulted
- an offset wider than `long long`
- offset at the operand length, length past the end, negative offset, negative
  length, empty operand

Verified the tests catch the bug rather than merely passing: against the
unfixed extension the suite segfaults the interpreter.

`tests/bsv/script/` + `tests/bsv/native/`: 552 passed, 4 skipped. black and ruff
clean.

## Related

Found while auditing the script VM against the reference SDKs after #197. That
audit turned up further confirmed divergences — `OP_CODESEPARATOR` off-by-one in
the signed subscript, `OP_DIV`/`OP_MOD` sign handling, and a native/pure-Python
split on high-S signatures — which will follow as separate PRs. This one is
first because it is the only memory-safety issue among them.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)