### PR TITLE
fix(script): truncate OP_DIV/OP_MOD toward zero, fix OP_NUM2BIN on zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **`OP_DIV` and `OP_MOD` now truncate toward zero** — both used Python's `//` and `%`, which floor the quotient and take the remainder's sign from the divisor. The TS SDK (BigInt `/` and `%`) and the Go SDK (`big.Int.Quo` and `big.Int.Rem`) truncate toward zero and take the remainder's sign from the dividend. Whenever the operand signs disagreed and the division was inexact, the results differed by one: `-7 2 OP_DIV` returned `-4` instead of `-3`, and `-7 2 OP_MOD` returned `1` instead of `-1`. No error was raised — the wrong value simply propagated, so a script could validate here and fail on the other SDKs, or the reverse. `OP_2DIV` was already correct and is unchanged.
+- **`OP_NUM2BIN` no longer raises out of `validate()` when widening zero** — zero encodes to no bytes, and the widening path then combined an `int` with a `bytes` sentinel and indexed an empty buffer. `OP_0 OP_4 OP_NUM2BIN` raised `TypeError` on the pure-Python VM (and `IndexError` for a zero size) where the native VM returned the correct result, so the two paths disagreed and the exception escaped `Spend.validate()` as neither a script evaluation error nor `False`. A value that already occupies the requested width now returns directly, as in the TS and Go SDKs.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2891,6 +2891,31 @@ static int c_checksig_verify(VMState *st,
     return ok ? 1 : 0;
 }
 
+/* Truncating division / remainder: the quotient rounds toward zero and the
+   remainder takes the dividend's sign, matching the TS/Go SDKs. Python's
+   floor semantics differ from both whenever the operand signs disagree.
+   Operating on absolute values keeps the two rules in one place. */
+static PyObject *num_trunc_div_or_mod(PyObject *a, PyObject *b, int want_mod) {
+    PyObject *aa = PyNumber_Absolute(a);
+    PyObject *ab = PyNumber_Absolute(b);
+    if (!aa || !ab) { Py_XDECREF(aa); Py_XDECREF(ab); return NULL; }
+    PyObject *res = want_mod ? PyNumber_Remainder(aa, ab) : PyNumber_FloorDivide(aa, ab);
+    Py_DECREF(aa); Py_DECREF(ab);
+    if (!res) return NULL;
+    PyObject *zero = PyLong_FromLong(0);
+    if (!zero) { Py_DECREF(res); return NULL; }
+    int a_neg = PyObject_RichCompareBool(a, zero, Py_LT);
+    int b_neg = PyObject_RichCompareBool(b, zero, Py_LT);
+    Py_DECREF(zero);
+    if (a_neg < 0 || b_neg < 0) { Py_DECREF(res); return NULL; }
+    if (want_mod ? a_neg : (a_neg != b_neg)) {
+        PyObject *neg = PyNumber_Negative(res);
+        Py_DECREF(res);
+        res = neg;
+    }
+    return res;
+}
+
 /* --- vm_step: execute one opcode ---------------------------------------- */
 /* Returns: 0 = success (increment PC), 1 = don't increment PC, -1 = error */
 
@@ -3533,14 +3558,14 @@ static int vm_step(VMState *st) {
                 vm_error(st, "OP_DIV cannot divide by zero!");
                 return -1;
             }
-            r = PyNumber_FloorDivide(x1, x2); break;
+            r = num_trunc_div_or_mod(x1, x2, 0); break;
         case 0x97:
             if (PyObject_RichCompareBool(x2, pz, Py_EQ) > 0) {
                 Py_DECREF(x1); Py_DECREF(x2); Py_DECREF(pz);
                 vm_error(st, "OP_MOD cannot divide by zero!");
                 return -1;
             }
-            r = PyNumber_Remainder(x1, x2); break;
+            r = num_trunc_div_or_mod(x1, x2, 1); break;
         case 0x9A: {
             int a = PyObject_IsTrue(x1), b = PyObject_IsTrue(x2);
             r = PyLong_FromLong((a > 0 && b > 0) ? 1 : 0); break;

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -551,11 +551,18 @@ class Spend:
                 elif current_opcode == OpCode.OP_DIV:
                     if x2 == 0:
                         self.script_evaluation_error("OP_DIV cannot divide by zero!")
-                    x = x1 // x2
+                    # Truncate toward zero, not floor: `//` would round -7 // 2
+                    # to -4 where the TS/Go SDKs give -3.
+                    x = abs(x1) // abs(x2)
+                    if (x1 < 0) != (x2 < 0):
+                        x = -x
                 elif current_opcode == OpCode.OP_MOD:
                     if x2 == 0:
                         self.script_evaluation_error("OP_MOD cannot divide by zero!")
-                    x = x1 % x2
+                    # Remainder takes the dividend's sign, not the divisor's.
+                    x = abs(x1) % abs(x2)
+                    if x1 < 0:
+                        x = -x
                 elif current_opcode == OpCode.OP_BOOLAND:
                     x = 1 if x1 != 0 and x2 != 0 else 0
                 elif current_opcode == OpCode.OP_BOOLOR:
@@ -824,14 +831,19 @@ class Spend:
                     )
                     self.script_evaluation_error(_m)
 
-                msb = b"\x00"
-                if len(x) > 0:
-                    msb = x[-1] & 0x80
-                    x[-1] &= 0x7F
-                octets = x + b"\x00" * (size - len(x))
-                octets[-1] |= msb
-
-                self.stack.append(octets)
+                # Already the requested width: the sign bit needs no relocating,
+                # and returning here keeps the zero-length case off the code
+                # below, which indexes the last byte.
+                if len(x) == size:
+                    self.stack.append(x)
+                else:
+                    msb = 0
+                    if len(x) > 0:
+                        msb = x[-1] & 0x80
+                        x[-1] &= 0x7F
+                    octets = x + b"\x00" * (size - len(x))
+                    octets[-1] |= msb
+                    self.stack.append(octets)
 
             elif current_opcode == OpCode.OP_BIN2NUM:
                 if len(self.stack) < 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_arithmetic_opcodes.py
+++ b/tests/bsv/script/test_arithmetic_opcodes.py
@@ -1,0 +1,87 @@
+"""Conformance tests for OP_DIV, OP_MOD and OP_NUM2BIN.
+
+Division truncates toward zero and the remainder takes the dividend's sign,
+matching the TS SDK (BigInt `/` and `%`) and the Go SDK (`big.Int.Quo` and
+`big.Int.Rem`). Python's `//` and `%` follow neither for mixed-sign operands.
+"""
+
+import pytest
+
+from bsv.script.spend import _USE_NATIVE_VM
+
+from .conftest import make_spend
+
+# script-number encodings used below: 0x81 = -1, 0x82 = -2, 0x87 = -7, 0x88 = -8
+DIV_VECTORS = [
+    ("07", "02", "03"),  # 7 / 2 = 3
+    ("87", "02", "83"),  # -7 / 2 = -3, not -4
+    ("07", "82", "83"),  # 7 / -2 = -3, not -4
+    ("87", "82", "03"),  # -7 / -2 = 3
+    ("81", "02", "OP_0"),  # -1 / 2 = 0, not -1
+    ("88", "02", "84"),  # -8 / 2 = -4 (exact, both conventions agree)
+]
+
+MOD_VECTORS = [
+    ("07", "02", "01"),  # 7 % 2 = 1
+    ("87", "02", "81"),  # -7 % 2 = -1, not 1
+    ("07", "82", "01"),  # 7 % -2 = 1, not -1
+    ("87", "82", "81"),  # -7 % -2 = -1
+    ("88", "02", "OP_0"),  # -8 % 2 = 0
+]
+
+NUM2BIN_VECTORS = [
+    ("OP_0", "OP_0", "OP_0"),  # zero into zero bytes
+    ("OP_0", "OP_1", "00"),
+    ("OP_0", "OP_4", "00000000"),
+    ("OP_1", "OP_4", "01000000"),
+    ("81", "OP_1", "81"),  # -1 already fits
+    ("81", "OP_4", "01000080"),  # sign bit moves to the new high byte
+]
+
+
+def _run_both_paths(asm: str, tx_version: int = 2) -> list:
+    """Return each VM path's result so native and Python stay in lockstep."""
+    results = [make_spend(asm, tx_version=tx_version)._validate_python()]
+    if _USE_NATIVE_VM:
+        results.append(make_spend(asm, tx_version=tx_version)._validate_native())
+    return results
+
+
+@pytest.mark.parametrize("dividend,divisor,expected", DIV_VECTORS)
+def test_div_truncates_toward_zero(dividend, divisor, expected):
+    assert all(_run_both_paths(f"{dividend} {divisor} OP_DIV {expected} OP_EQUAL"))
+
+
+@pytest.mark.parametrize("dividend,divisor,expected", MOD_VECTORS)
+def test_mod_takes_dividend_sign(dividend, divisor, expected):
+    assert all(_run_both_paths(f"{dividend} {divisor} OP_MOD {expected} OP_EQUAL"))
+
+
+@pytest.mark.parametrize("opcode", ["OP_DIV", "OP_MOD"])
+def test_division_by_zero_is_rejected(opcode):
+    spend = make_spend(f"07 OP_0 {opcode} OP_TRUE", tx_version=2)
+    with pytest.raises(RuntimeError, match="divide by zero"):
+        spend._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = make_spend(f"07 OP_0 {opcode} OP_TRUE", tx_version=2)
+        with pytest.raises(RuntimeError, match="divide by zero"):
+            native_spend._validate_native()
+
+
+@pytest.mark.parametrize("value,size,expected", NUM2BIN_VECTORS)
+def test_num2bin_widens_to_requested_size(value, size, expected):
+    # Regression: zero encodes to no bytes, and the widening path then mixed an
+    # int with a bytes sentinel and indexed an empty buffer -- the pure-Python
+    # VM raised TypeError/IndexError out of validate() where the native VM
+    # returned a result.
+    assert all(_run_both_paths(f"{value} {size} OP_NUM2BIN {expected} OP_EQUAL"))
+
+
+def test_num2bin_rejects_size_smaller_than_value():
+    spend = make_spend("0102 OP_1 OP_NUM2BIN OP_TRUE", tx_version=2)
+    with pytest.raises(RuntimeError, match="OP_NUM2BIN"):
+        spend._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = make_spend("0102 OP_1 OP_NUM2BIN OP_TRUE", tx_version=2)
+        with pytest.raises(RuntimeError, match="OP_NUM2BIN"):
+            native_spend._validate_native()


### PR DESCRIPTION
## What

### 1. `OP_DIV` / `OP_MOD` returned silently wrong values

Both used Python's `//` and `%`, which floor the quotient and take the
remainder's sign from the divisor. The TS SDK (BigInt `/` and `%`) and the Go
SDK (`big.Int.Quo` / `big.Int.Rem`) truncate toward zero and take the
remainder's sign from the dividend.

Whenever the operand signs disagree and the division is inexact, the results
differ by one:

| script | py-sdk (before) | TS / Go |
|---|---|---|
| `-7 2 OP_DIV` | `-4` | `-3` |
| `7 -2 OP_DIV` | `-4` | `-3` |
| `-1 2 OP_DIV` | `-1` | `0` |
| `-7 2 OP_MOD` | `1` | `-1` |
| `7 -2 OP_MOD` | `-1` | `1` |

Nothing errors — the wrong value simply propagates, so a script can validate
here and fail on the other SDKs, or the reverse.

`OP_2DIV` was already implemented as an explicit truncation
(`int(x / 2) if x >= 0 else -int(-x / 2)`) and matches the references, so
py-sdk was correct when dividing by two and wrong for general division.

### 2. `OP_NUM2BIN` raised out of `validate()` when widening zero

Zero encodes to no bytes. The widening path then set `msb = b"\x00"` (bytes)
instead of an int and indexed the last byte of a possibly-empty buffer:

| script | Python VM (before) | native VM |
|---|---|---|
| `OP_0 OP_4 OP_NUM2BIN` | `TypeError` | `00000000` |
| `OP_0 OP_0 OP_NUM2BIN` | `IndexError` | empty |

So the two VM paths disagreed, and the exception escaped `Spend.validate()` as
neither a script evaluation error nor `False` — `_validate_python()` does not
catch it. A caller would see a raw `TypeError` from what should be a script
failure.

## Fix

Division and remainder now operate on absolute values with the sign applied
afterwards, which expresses both rules in one place. The C extension gets a
single `num_trunc_div_or_mod` helper rather than repeating the sign handling at
each call site.

`OP_NUM2BIN` returns directly when the value already occupies the requested
width — the same early return the TS SDK, Go SDK and this repo's own C
extension already had. That keeps the zero-length case away from the code that
indexes the last byte, and `msb` is an int in every path.

Both VM paths shared each defect and are fixed together.

## Testing

New `tests/bsv/script/test_arithmetic_opcodes.py`, every case run through
**both** VM paths:

- 6 division and 5 remainder vectors covering each sign combination, the exact
  cases where both conventions agree, and the `-1 / 2` case where they differ
  most visibly
- division by zero still rejected on both opcodes
- 6 `OP_NUM2BIN` vectors including zero into zero bytes, zero into four bytes,
  and `-1` widened so the sign bit relocates to the new high byte
- size smaller than the value still rejected

Verified the tests catch the bugs rather than merely passing: 8 of 20 fail
against the unfixed code.

`tests/bsv/script/` + `tests/bsv/native/`: 558 passed, 4 skipped. black and ruff
clean.

## Related

Third PR from the script VM audit against the reference SDKs, after #197
(shift opcodes) and #198 (`OP_SUBSTR` out-of-bounds read). Still outstanding
from that audit, to follow separately: the `OP_CODESEPARATOR` off-by-one in the
signed subscript, a native/pure-Python split on high-S signatures under
Chronicle relaxation, and VM state carrying across the unlocking→locking script
boundary.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)