### PR TITLE
fix(script): exclude OP_CODESEPARATOR from the signed subscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **`OP_CODESEPARATOR` no longer leaves itself in the signed subscript** — the subscript a signature commits to started *at* the last separator instead of past it, so the `OP_CODESEPARATOR` byte (`0xab`) entered the sighash preimage. For `<pubkey> OP_CODESEPARATOR OP_CHECKSIG` the scriptCode was `abac` where the TS and Go SDKs both use `ac`, so a signature produced by either of them failed to verify here and one produced here failed there. Affects `OP_CHECKSIG`, `OP_CHECKSIGVERIFY`, `OP_CHECKMULTISIG` and `OP_CHECKMULTISIGVERIFY` on both VM paths. A separator in the very first position is unchanged: index 0 is indistinguishable from "no separator seen", so the whole script stays in the subscript, matching the Go SDK that Teranode builds on. (The TS SDK excludes the separator in that position as well — the one place the two references disagree.)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **`OP_CODESEPARATOR` no longer leaves itself in the signed subscript** — the subscript a signature commits to started *at* the last separator instead of past it, so the `OP_CODESEPARATOR` byte (`0xab`) entered the sighash preimage. For `<pubkey> OP_CODESEPARATOR OP_CHECKSIG` the scriptCode was `abac` where the TS and Go SDKs both use `ac`, so a signature produced by either of them failed to verify here and one produced here failed there. Affects `OP_CHECKSIG`, `OP_CHECKSIGVERIFY`, `OP_CHECKMULTISIG` and `OP_CHECKMULTISIGVERIFY` on both VM paths. A separator in the very first position is unchanged: index 0 is indistinguishable from "no separator seen", so the whole script stays in the subscript, matching the Go SDK that Teranode builds on. (The TS SDK excludes the separator in that position as well — the one place the two references disagree.)
+- **`OP_CODESEPARATOR` no longer leaves itself in the signed subscript** — the subscript a signature commits to started *at* the last separator instead of past it, so the `OP_CODESEPARATOR` byte (`0xab`) entered the sighash preimage. For `<pubkey> OP_CODESEPARATOR OP_CHECKSIG` the scriptCode was `abac` where the TS and Go SDKs both use `ac`, so a signature produced by either of them failed to verify here and one produced here failed there. Affects `OP_CHECKSIG`, `OP_CHECKSIGVERIFY`, `OP_CHECKMULTISIG` and `OP_CHECKMULTISIGVERIFY` on both VM paths. The separator is excluded wherever it sits, first position included, as in the node (`interpreter.cpp` advances past the opcode before recording the position — "Hash starts after the code separator").
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2651,7 +2651,11 @@ static int c_build_subscript(VMState *st,
     PyObject *chunks = (st->context == VM_CTX_UNLOCK)
                        ? st->unlock_chunks : st->lock_chunks;
     Py_ssize_t clen = PyList_GET_SIZE(chunks);
-    Py_ssize_t start = st->last_code_separator;
+    /* Past the separator, not at it: including the OP_CODESEPARATOR byte would
+       change the sighash preimage. Index 0 reads as "none seen", so a separator
+       in the very first position leaves the whole script -- matching the Go SDK
+       that Teranode builds on. */
+    Py_ssize_t start = st->last_code_separator > 0 ? st->last_code_separator + 1 : 0;
 
     size_t cap = 256;
     unsigned char *buf = (unsigned char *)malloc(cap);

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2652,10 +2652,9 @@ static int c_build_subscript(VMState *st,
                        ? st->unlock_chunks : st->lock_chunks;
     Py_ssize_t clen = PyList_GET_SIZE(chunks);
     /* Past the separator, not at it: including the OP_CODESEPARATOR byte would
-       change the sighash preimage. Index 0 reads as "none seen", so a separator
-       in the very first position leaves the whole script -- matching the Go SDK
-       that Teranode builds on. */
-    Py_ssize_t start = st->last_code_separator > 0 ? st->last_code_separator + 1 : 0;
+       change the sighash preimage. -1 means none was seen, so start at 0. The
+       node excludes the separator wherever it sits, first position included. */
+    Py_ssize_t start = st->last_code_separator + 1;
 
     size_t cap = 256;
     unsigned char *buf = (unsigned char *)malloc(cap);
@@ -4288,7 +4287,7 @@ static PyObject *pyfn_spend_validate(PyObject *self, PyObject *args) {
     st.lock_chunks = lock_chunks;
     st.program_counter = 0;
     st.context = VM_CTX_UNLOCK;
-    st.last_code_separator = 0;
+    st.last_code_separator = -1;  /* none seen yet */
     st.tx_version = tx_version;
     st.source_txid = source_txid;
     st.source_output_index = source_output_index;

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -629,11 +629,7 @@ class Spend:
                     _m = f"{_codename} requires correct encoding for the public key and signature."
                     self.script_evaluation_error(_m)
 
-                # Subset of script starting at the most recent code separator
-                if self.context == "UnlockingScript":
-                    sub_script = Script.from_chunks(self.unlocking_script.chunks[self.last_code_separator :])
-                else:
-                    sub_script = Script.from_chunks(self.locking_script.chunks[self.last_code_separator :])
+                sub_script = self.subscript_after_code_separator()
 
                 # Drop the signature, since there's no way for a signature to sign itself
                 sub_script = Script.find_and_delete(sub_script, Script.write_bin(sig))
@@ -689,11 +685,7 @@ class Spend:
                     )
                     self.script_evaluation_error(_m)
 
-                # Subset of script starting at the most recent code separator
-                if self.context == "UnlockingScript":
-                    sub_script = Script.from_chunks(self.unlocking_script.chunks[self.last_code_separator :])
-                else:
-                    sub_script = Script.from_chunks(self.locking_script.chunks[self.last_code_separator :])
+                sub_script = self.subscript_after_code_separator()
 
                 # Drop the signatures, since there's no way for a signature to sign itself
                 for j in range(sigs_count):
@@ -907,6 +899,20 @@ class Spend:
             self.script_evaluation_error("The top stack element must be truthy after script evaluation.")
 
         return True
+
+    def subscript_after_code_separator(self) -> Script:
+        """The script a signature commits to: everything past the last OP_CODESEPARATOR.
+
+        The separator itself is excluded, as in the TS/Go SDKs — including it
+        would change the sighash preimage and break signatures across SDKs.
+        """
+        chunks = self.unlocking_script.chunks if self.context == "UnlockingScript" else self.locking_script.chunks
+        # Index 0 reads as "none seen" here, so a separator in the very first
+        # position leaves the whole script in the subscript. That matches the Go
+        # SDK, and Teranode builds on it; the TS SDK excludes the separator in
+        # that position too, so the two references disagree only there.
+        start = self.last_code_separator + 1 if self.last_code_separator else 0
+        return Script.from_chunks(chunks[start:])
 
     def stacktop(self, i: int) -> bytes:
         return self.stack[len(self.stack) + i]

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -907,11 +907,11 @@ class Spend:
         would change the sighash preimage and break signatures across SDKs.
         """
         chunks = self.unlocking_script.chunks if self.context == "UnlockingScript" else self.locking_script.chunks
-        # Index 0 reads as "none seen" here, so a separator in the very first
-        # position leaves the whole script in the subscript. That matches the Go
-        # SDK, and Teranode builds on it; the TS SDK excludes the separator in
-        # that position too, so the two references disagree only there.
-        start = self.last_code_separator + 1 if self.last_code_separator else 0
+        # The separator is excluded wherever it sits, including the first
+        # position. The node advances past the opcode before recording the
+        # position ("Hash starts after the code separator", interpreter.cpp),
+        # so there is no special case for index 0.
+        start = 0 if self.last_code_separator is None else self.last_code_separator + 1
         return Script.from_chunks(chunks[start:])
 
     def stacktop(self, i: int) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/live/test_live_standard_opcodes.py
+++ b/tests/bsv/live/test_live_standard_opcodes.py
@@ -19,6 +19,32 @@ from .conftest import (
     p2pkh_lock_with_prefix,
 )
 
+
+def custom_unlock_over_subscript(priv_key, subscript: Script):
+    """Sign against `subscript` rather than the input's full locking script.
+
+    Needed when the locking script contains OP_CODESEPARATOR: the signature
+    commits only to what follows it.
+    """
+    from bsv.script.type import to_unlock_script_template
+
+    def sign(tx, input_index) -> Script:
+        tx_input = tx.inputs[input_index]
+        original = tx_input.locking_script
+        tx_input.locking_script = subscript
+        try:
+            preimage = tx.preimage(input_index)
+        finally:
+            tx_input.locking_script = original
+        signature = priv_key.sign(preimage)
+        return Script(
+            encode_pushdata(signature + tx_input.sighash.to_bytes(1, "little"))
+            + encode_pushdata(priv_key.public_key().serialize())
+        )
+
+    return to_unlock_script_template(sign, lambda: 200)
+
+
 # Default: BIP143 v1. A subset also tested with OTDA v2.
 SH = SIGHASH.ALL_FORKID
 SH_C = SIGHASH.ALL_FORKID_CHRONICLE
@@ -456,17 +482,17 @@ class TestCryptoOps:
         build_signed_tx(lock, unlock, sighash=SH, tx_version=1)
 
     def test_op_codeseparator(self, priv_key):
-        """OP_CODESEPARATOR before CHECKSIG changes subscript for sig hash."""
+        """OP_CODESEPARATOR before CHECKSIG changes subscript for sig hash.
+
+        The signature must commit to the script *after* the separator, so the
+        template signs `subscript` while the output is locked with `lock`.
+        """
         pkh = hash160(priv_key.public_key().serialize())
-        lock = Script(
-            OpCode.OP_CODESEPARATOR
-            + OpCode.OP_DUP
-            + OpCode.OP_HASH160
-            + encode_pushdata(pkh)
-            + OpCode.OP_EQUALVERIFY
-            + OpCode.OP_CHECKSIG
+        subscript = Script(
+            OpCode.OP_DUP + OpCode.OP_HASH160 + encode_pushdata(pkh) + OpCode.OP_EQUALVERIFY + OpCode.OP_CHECKSIG
         )
-        unlock = custom_unlock(priv_key)
+        lock = Script(OpCode.OP_CODESEPARATOR + subscript.serialize())
+        unlock = custom_unlock_over_subscript(priv_key, subscript)
         build_signed_tx(lock, unlock, sighash=SH, tx_version=1)
 
 

--- a/tests/bsv/script/test_codeseparator_subscript.py
+++ b/tests/bsv/script/test_codeseparator_subscript.py
@@ -1,0 +1,130 @@
+"""OP_CODESEPARATOR defines where the signed subscript starts.
+
+The subscript runs from *past* the last OP_CODESEPARATOR, excluding the
+separator byte itself, as in the TS SDK (`Spend.ts`) and Go SDK
+(`interpreter/thread.go`). Including it changes the sighash preimage, so a
+signature made by another SDK would not verify here and vice versa.
+"""
+
+import pytest
+
+from bsv.constants import SIGHASH, OpCode
+from bsv.keys import PrivateKey
+from bsv.script.script import Script
+from bsv.script.spend import _USE_NATIVE_VM, Spend
+from bsv.transaction_input import TransactionInput
+from bsv.transaction_output import TransactionOutput
+from bsv.transaction_preimage import tx_preimage
+from bsv.utils import encode_pushdata
+
+SOURCE_TXID = "11" * 32
+SOURCE_SATOSHIS = 10_000
+TX_VERSION = 2
+SIGHASH_FLAG = SIGHASH.ALL_FORKID
+
+
+@pytest.fixture
+def priv_key():
+    return PrivateKey()
+
+
+def _outputs():
+    return [TransactionOutput(locking_script=Script.from_asm("OP_TRUE"), satoshis=9_000)]
+
+
+def _preimage_over(subscript: Script) -> bytes:
+    """Preimage a signature commits to when the scriptCode is `subscript`."""
+    inp = TransactionInput(
+        source_txid=SOURCE_TXID,
+        source_output_index=0,
+        unlocking_script=Script(),
+        sequence=0xFFFFFFFF,
+        sighash=SIGHASH_FLAG,
+    )
+    inp.locking_script = subscript
+    inp.satoshis = SOURCE_SATOSHIS
+    return tx_preimage(0, [inp], _outputs(), TX_VERSION, 0)
+
+
+def _spend(locking: Script, unlocking: Script) -> Spend:
+    return Spend(
+        {
+            "sourceTXID": SOURCE_TXID,
+            "sourceOutputIndex": 0,
+            "sourceSatoshis": SOURCE_SATOSHIS,
+            "lockingScript": locking,
+            "transactionVersion": TX_VERSION,
+            "otherInputs": [],
+            "outputs": _outputs(),
+            "inputIndex": 0,
+            "unlockingScript": unlocking,
+            "inputSequence": 0xFFFFFFFF,
+            "lockTime": 0,
+        }
+    )
+
+
+def _sign_over(priv_key, subscript: Script) -> Script:
+    sig = priv_key.sign(_preimage_over(subscript))
+    return Script(encode_pushdata(sig + SIGHASH_FLAG.to_bytes(1, "little")))
+
+
+def _validates_on_both_paths(locking: Script, unlocking: Script) -> list:
+    results = []
+    for use_native in (False, True):
+        if use_native and not _USE_NATIVE_VM:
+            continue
+        spend = _spend(locking, unlocking)
+        try:
+            results.append(spend._validate_native() if use_native else spend._validate_python())
+        except RuntimeError:
+            results.append(False)
+    return results
+
+
+def _locking_with_separator(priv_key, trailing_separators: int = 1) -> Script:
+    pubkey_push = encode_pushdata(priv_key.public_key().serialize())
+    return Script(pubkey_push + OpCode.OP_CODESEPARATOR * trailing_separators + OpCode.OP_CHECKSIG)
+
+
+def test_signature_over_subscript_excluding_separator_is_accepted(priv_key):
+    # Everything past the separator is just OP_CHECKSIG.
+    locking = _locking_with_separator(priv_key)
+    unlocking = _sign_over(priv_key, Script(OpCode.OP_CHECKSIG))
+    assert all(_validates_on_both_paths(locking, unlocking))
+
+
+def test_signature_over_subscript_including_separator_is_rejected(priv_key):
+    # Regression: the subscript started *at* the separator, so this — a
+    # signature over `OP_CODESEPARATOR OP_CHECKSIG` — was what py-sdk accepted,
+    # and the signature the reference SDKs produce was rejected.
+    locking = _locking_with_separator(priv_key)
+    unlocking = _sign_over(priv_key, Script(OpCode.OP_CODESEPARATOR + OpCode.OP_CHECKSIG))
+    assert not any(_validates_on_both_paths(locking, unlocking))
+
+
+def test_only_the_last_separator_counts(priv_key):
+    # Two separators in a row: the subscript still starts after the last one.
+    locking = _locking_with_separator(priv_key, trailing_separators=2)
+    unlocking = _sign_over(priv_key, Script(OpCode.OP_CHECKSIG))
+    assert all(_validates_on_both_paths(locking, unlocking))
+
+
+def test_separator_in_first_position_leaves_whole_script(priv_key):
+    # Index 0 is indistinguishable from "no separator seen", so a leading
+    # separator keeps the whole script in the subscript. The Go SDK behaves this
+    # way and Teranode builds on it; the TS SDK excludes the separator here too,
+    # so this is the one position where the references disagree.
+    pubkey_push = encode_pushdata(priv_key.public_key().serialize())
+    locking = Script(OpCode.OP_CODESEPARATOR + pubkey_push + OpCode.OP_CHECKSIG)
+    unlocking = _sign_over(priv_key, locking)
+    assert all(_validates_on_both_paths(locking, unlocking))
+
+
+def test_without_separator_the_whole_script_is_signed(priv_key):
+    # No separator: the subscript is the entire locking script, unchanged
+    # behaviour that the off-by-one fix must not disturb.
+    pubkey_push = encode_pushdata(priv_key.public_key().serialize())
+    locking = Script(pubkey_push + OpCode.OP_CHECKSIG)
+    unlocking = _sign_over(priv_key, locking)
+    assert all(_validates_on_both_paths(locking, unlocking))

--- a/tests/bsv/script/test_codeseparator_subscript.py
+++ b/tests/bsv/script/test_codeseparator_subscript.py
@@ -110,14 +110,12 @@ def test_only_the_last_separator_counts(priv_key):
     assert all(_validates_on_both_paths(locking, unlocking))
 
 
-def test_separator_in_first_position_leaves_whole_script(priv_key):
-    # Index 0 is indistinguishable from "no separator seen", so a leading
-    # separator keeps the whole script in the subscript. The Go SDK behaves this
-    # way and Teranode builds on it; the TS SDK excludes the separator here too,
-    # so this is the one position where the references disagree.
+def test_separator_in_first_position_is_also_excluded(priv_key):
+    # No special case for index 0: the node advances past the opcode before
+    # recording the position, so a leading separator is excluded like any other.
     pubkey_push = encode_pushdata(priv_key.public_key().serialize())
     locking = Script(OpCode.OP_CODESEPARATOR + pubkey_push + OpCode.OP_CHECKSIG)
-    unlocking = _sign_over(priv_key, locking)
+    unlocking = _sign_over(priv_key, Script(pubkey_push + OpCode.OP_CHECKSIG))
     assert all(_validates_on_both_paths(locking, unlocking))
 
 


### PR DESCRIPTION
## What

The subscript a signature commits to started **at** the last
`OP_CODESEPARATOR` instead of past it, so the separator byte (`0xab`) entered
the sighash preimage.

Observed directly by capturing the scriptCode for
`<pubkey> OP_CODESEPARATOR OP_CHECKSIG`:

| | scriptCode |
|---|---|
| py-sdk (before) | `abac` |
| BSV node / TS SDK / Go SDK | `ac` |

A signature produced by any of them therefore failed to verify here, and one
produced here failed there. This affects `OP_CHECKSIG`, `OP_CHECKSIGVERIFY`,
`OP_CHECKMULTISIG` and `OP_CHECKMULTISIGVERIFY`, on both VM paths — the C
extension and the pure-Python fallback shared the defect.

## Fix

The subscript starts one chunk past the separator, wherever it sits.

The authority here is the node (`src/script/interpreter.cpp`): the main loop
calls `script.GetOp(pc, opcode, vchPushValue)`, which advances `pc` past the
opcode *before* the switch runs, so

```cpp
case OP_CODESEPARATOR: {
    // Hash starts after the code separator
    pbegincodehash = pc;
} break;
```

already points past the separator, with no guard on the position. A separator
in the first opcode is excluded like any other. The TS SDK agrees
(`slice(lastCodeSeparator === null ? 0 : lastCodeSeparator + 1)`).

The Go SDK guards with `if t.lastCodeSep > 0` before adding one, which
conflates "separator at index 0" with "no separator seen" and keeps the
separator in the subscript for that one position. **An earlier version of this
branch matched Go there and was wrong** — it reproduced a Go bug and diverged
from the node. The C extension now uses `-1` as its "none seen" sentinel so
index 0 stays distinguishable.

The four call sites that recomputed this slice inline are replaced by a single
`subscript_after_code_separator()` method — getting it right in three of four
places would have been its own bug.

## Testing

New `tests/bsv/script/test_codeseparator_subscript.py` — end-to-end, signing
with real keys over an explicit scriptCode and validating through **both** VM
paths:

- a signature over the subscript *excluding* the separator is accepted
- a signature over the subscript *including* it is rejected (the exact inverse
  of the old behaviour)
- with two separators, only the last one counts
- a separator in the first position is excluded too
- with no separator at all the whole script is signed, unchanged

Verified the tests catch the bug rather than merely passing: 3 of 5 fail
against the unfixed code.

### One existing test corrected

`tests/bsv/live/test_live_standard_opcodes.py::TestCryptoOps::test_op_codeseparator`
used a leading separator and signed over the *full* locking script. It passed
only because of the bug this PR fixes — its own docstring says the separator
"changes subscript for sig hash", which was exactly what did not happen. It now
signs over the subscript, so it tests what it claims.

Full suite: 3784 passed, 262 skipped. black and ruff clean.

## Related

Fourth PR from the script VM audit, after #197 (shift opcodes), #198
(`OP_SUBSTR` out-of-bounds read) and #199 (`OP_DIV`/`OP_MOD` sign handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)