### PR TITLE
fix(script): accept high-S signatures on the pure-Python VM too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **The pure-Python VM rejected high-S signatures the native VM accepts** — Chronicle relaxes the low-S requirement for transaction version > 1, and a high-S signature is mathematically valid, so the native VM folds it to its low-S equivalent (`secp256k1_ecdsa_signature_normalize`) before verifying. The pure-Python VM verified through `PublicKey.verify`, which rejects the high-S form outright, so an environment without the C extension refused transactions the network accepts. Script verification now normalizes on both paths; whether high-S is *allowed* stays with `check_signature_encoding`, which still rejects it for version ≤ 1. `PublicKey.verify` is unchanged and continues to require low-S.
+- **Low-S rejections no longer report as malformed signatures** — `check_signature_encoding` raised its low-S error from inside a `with suppress(Exception)` block, which swallowed it and fell through to "The signature format is invalid." The check now sits outside the suppression, so a high-S signature on a version-1 transaction says so.
 
 ---
 

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -7,7 +7,7 @@ from ..hash import hash160, hash256, ripemd160, sha1, sha256
 from ..keys import PublicKey
 from ..transaction_input import TransactionInput
 from ..transaction_preimage import tx_preimage
-from ..utils import deserialize_ecdsa_der, unsigned_to_bytes
+from ..utils import deserialize_ecdsa_der, serialize_ecdsa_der, unsigned_to_bytes
 from .script import Script, ScriptChunk
 
 try:
@@ -1003,12 +1003,16 @@ class Spend:
         if not SIGHASH.validate(sighash):
             self.script_evaluation_error("Invalid SIGHASH flag")
 
+        # The low-S check has to sit outside the suppression: raising from
+        # inside would be caught here and reported as a malformed signature.
+        s = None
         with suppress(Exception):
             _, s = deserialize_ecdsa_der(sig)
-            if not self.is_relaxed() and REQUIRE_LOW_S_SIGNATURES and s > curve.n // 2:
-                self.script_evaluation_error("The signature must have a low S value.")
-            return True
-        self.script_evaluation_error("The signature format is invalid.")
+        if s is None:
+            self.script_evaluation_error("The signature format is invalid.")
+        elif not self.is_relaxed() and REQUIRE_LOW_S_SIGNATURES and s > curve.n // 2:
+            self.script_evaluation_error("The signature must have a low S value.")
+        return True
 
     @classmethod
     def check_public_key_encoding(cls, octets: bytes) -> bool:
@@ -1016,6 +1020,24 @@ class Spend:
             PublicKey(octets)
             return True
         return False
+
+    @staticmethod
+    def normalize_low_s(der: bytes) -> bytes:
+        """Fold a high-S signature to its low-S equivalent.
+
+        Both encode the same valid signature, but `PublicKey.verify` rejects the
+        high-S form outright. Whether high-S is *allowed* is a policy question
+        `check_signature_encoding` already answers -- Chronicle relaxes it for
+        transaction version > 1 -- so verification itself must not re-impose it.
+        The native VM normalizes here too, via `secp256k1_ecdsa_signature_normalize`.
+        """
+        try:
+            r, s = deserialize_ecdsa_der(der)
+        except ValueError:
+            return der
+        if s <= curve.n // 2:
+            return der
+        return serialize_ecdsa_der((r, curve.n - s))
 
     def verify_signature(self, sig: bytes, pub_key: bytes, sub_script: Script) -> bool:
         if sig == b"":
@@ -1035,7 +1057,7 @@ class Spend:
         inputs.insert(self.input_index, current_input)
 
         preimage = tx_preimage(self.input_index, inputs, self.outputs, self.transaction_version, self.lock_time)
-        return PublicKey(pub_key).verify(sig[:-1], preimage)
+        return PublicKey(pub_key).verify(self.normalize_low_s(sig[:-1]), preimage)
 
     @classmethod
     def encode_bool(cls, f: bool) -> bytes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_high_s_vm_parity.py
+++ b/tests/bsv/script/test_high_s_vm_parity.py
@@ -1,0 +1,112 @@
+"""High-S signatures must be judged the same by both VM paths.
+
+Chronicle relaxes the low-S requirement for transaction version > 1, so a
+high-S signature is valid there. The native VM folds the signature to its
+low-S equivalent before verifying; the pure-Python VM went through
+`PublicKey.verify`, which rejects the high-S form outright, so the two paths
+disagreed on transactions the network accepts.
+"""
+
+import pytest
+
+from bsv.constants import NUMBER_BYTE_LENGTH, SIGHASH
+from bsv.curve import curve
+from bsv.keys import PrivateKey
+from bsv.script.script import Script
+from bsv.script.spend import _USE_NATIVE_VM, Spend
+from bsv.script.type import P2PKH
+from bsv.transaction_input import TransactionInput
+from bsv.transaction_output import TransactionOutput
+from bsv.transaction_preimage import tx_preimage
+from bsv.utils import deserialize_ecdsa_der, encode_pushdata
+
+SOURCE_TXID = "22" * 32
+SOURCE_SATOSHIS = 10_000
+SIGHASH_FLAG = SIGHASH.ALL_FORKID
+
+
+@pytest.fixture
+def priv_key():
+    return PrivateKey()
+
+
+def _outputs():
+    return [TransactionOutput(locking_script=Script.from_asm("OP_TRUE"), satoshis=9_000)]
+
+
+def _der(r: int, s: int) -> bytes:
+    """Serialize without the low-S normalization `serialize_ecdsa_der` applies."""
+    parts = []
+    for v in (r, s):
+        b = v.to_bytes(NUMBER_BYTE_LENGTH, "big").lstrip(b"\x00")
+        if b[0] & 0x80:
+            b = b"\x00" + b
+        parts.append(bytes([0x02, len(b)]) + b)
+    body = b"".join(parts)
+    return bytes([0x30, len(body)]) + body
+
+
+def _high_s_unlocking(priv_key, locking: Script, tx_version: int) -> Script:
+    inp = TransactionInput(
+        source_txid=SOURCE_TXID,
+        source_output_index=0,
+        unlocking_script=Script(),
+        sequence=0xFFFFFFFF,
+        sighash=SIGHASH_FLAG,
+    )
+    inp.locking_script = locking
+    inp.satoshis = SOURCE_SATOSHIS
+    preimage = tx_preimage(0, [inp], _outputs(), tx_version, 0)
+
+    r, s = deserialize_ecdsa_der(priv_key.sign(preimage))
+    if s <= curve.n // 2:
+        s = curve.n - s  # force the high-S form
+    sig = _der(r, s) + SIGHASH_FLAG.to_bytes(1, "little")
+    return Script(encode_pushdata(sig) + encode_pushdata(priv_key.public_key().serialize()))
+
+
+def _results(priv_key, tx_version: int) -> list:
+    locking = P2PKH().lock(priv_key.address())
+    unlocking = _high_s_unlocking(priv_key, locking, tx_version)
+    out = []
+    for use_native in (False, True):
+        if use_native and not _USE_NATIVE_VM:
+            continue
+        spend = Spend(
+            {
+                "sourceTXID": SOURCE_TXID,
+                "sourceOutputIndex": 0,
+                "sourceSatoshis": SOURCE_SATOSHIS,
+                "lockingScript": locking,
+                "transactionVersion": tx_version,
+                "otherInputs": [],
+                "outputs": _outputs(),
+                "inputIndex": 0,
+                "unlockingScript": unlocking,
+                "inputSequence": 0xFFFFFFFF,
+                "lockTime": 0,
+            }
+        )
+        try:
+            out.append(spend._validate_native() if use_native else spend._validate_python())
+        except RuntimeError as e:
+            out.append(str(e))
+    return out
+
+
+def test_relaxed_version_accepts_high_s_on_both_paths(priv_key):
+    # Version 2 relaxes low-S, and a high-S signature is mathematically valid,
+    # so both VMs must accept it. The pure-Python VM used to reject.
+    assert _results(priv_key, tx_version=2) == [True] * (2 if _USE_NATIVE_VM else 1)
+
+
+def test_strict_version_rejects_high_s_on_both_paths(priv_key):
+    results = _results(priv_key, tx_version=1)
+    assert all(isinstance(r, str) for r in results), results
+
+
+def test_strict_rejection_names_the_low_s_rule(priv_key):
+    # The low-S error used to be raised inside a `suppress(Exception)` block
+    # that swallowed it, leaving the misleading "signature format is invalid".
+    for message in _results(priv_key, tx_version=1):
+        assert "low S value" in message, message


### PR DESCRIPTION
## What

Chronicle relaxes the low-S requirement for transaction version > 1. A high-S
signature is mathematically valid, so under that relaxation it must verify.

The two VM paths disagreed:

| | native VM | pure-Python VM |
|---|---|---|
| high-S, tx version 2 | accepts | **rejects** |

The native VM folds the signature to its low-S equivalent with
`secp256k1_ecdsa_signature_normalize` and verifies the normalized form
(`bsv_native.c`). The pure-Python VM verified through `PublicKey.verify`, which
calls `secp256k1_ecdsa_verify` directly — and libsecp256k1 rejects high-S by
design.

So an environment without the C extension refused transactions the network
accepts, and `Spend.validate()` returned a different answer depending only on
whether `_bsv_native` imported.

This was already visible in the suite:
`tests/bsv/live/test_live_malleability.py::TestLowSSignature::test_v2_bypasses_low_s_check`
passes normally but fails when the Python VM is forced — its own docstring says
"libsecp256k1 correctly verifies high-S signatures", which only held on one path.

### Second defect, same area

`check_signature_encoding` raised its low-S error from inside a
`with suppress(Exception)` block:

```python
with suppress(Exception):
    _, s = deserialize_ecdsa_der(sig)
    if ... and s > curve.n // 2:
        self.script_evaluation_error("The signature must have a low S value.")  # swallowed
    return True
self.script_evaluation_error("The signature format is invalid.")
```

The error it just raised was caught by its own suppression, so a version-1
transaction with a high-S signature was rejected as *malformed* rather than for
the rule it broke. `test_v1_rejects_high_s` asserts on that message and had been
passing only through the native path.

## Fix

Script verification normalizes the signature on both paths, via a small
`normalize_low_s` helper. Whether high-S is *allowed* stays with
`check_signature_encoding`, which still rejects it for version ≤ 1 — the policy
and the mechanics stay separate, and the native VM already worked this way.

`PublicKey.verify` is untouched and still requires low-S, as its docstring
promises; only the script VM relaxes it, and only where Chronicle says to.

The low-S check moves outside the suppression, which now covers just the DER
parse.

## Testing

New `tests/bsv/script/test_high_s_vm_parity.py`, running deliberately-high-S
signatures through **both** VM paths:

- version 2 accepts on both paths
- version 1 rejects on both paths
- the version-1 rejection names the low-S rule rather than reporting a
  malformed signature

Verified the tests catch the bugs rather than merely passing: 2 of 3 fail
against the unfixed code.

Both pre-existing `TestLowSSignature` tests now pass under the forced-Python VM
as well as natively — previously one failed on each.

`tests/bsv/script/` + `tests/bsv/native/` + `tests/bsv/live/`: 849 passed, 220
skipped. black and ruff clean.

## Related

Fifth PR from the script VM audit, after #197 (shift opcodes), #198
(`OP_SUBSTR` out-of-bounds read), #199 (`OP_DIV`/`OP_MOD` sign handling) and
#200 (`OP_CODESEPARATOR` subscript). Still outstanding: VM state carrying across
the unlocking→locking boundary, the `OP_VERIF`/`OP_RETURN`/`OP_ELSE` control-flow
divergences, and the missing script-number length bound.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)