### PR TITLE
fix(script): reset per-script VM state at the unlocking/locking boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **VM state no longer carries across the unlocking→locking script boundary** — only the data stack is meant to survive it, but the alt stack, the conditional stack and the code-separator position were all left in place. An unlocking script could therefore stash a value with `OP_TOALTSTACK` for the locking script to retrieve, open an `OP_IF` for the locking script to close, or move the code separator so the locking script signed a truncated subscript. Each of these is cleared at the boundary in the TS SDK (`Spend.ts`) and the Go SDK (`interpreter/thread.go`), and both also reject a conditional still open at the end of the unlocking script, as py-sdk now does on both VM paths.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2898,6 +2898,17 @@ static int vm_step(VMState *st) {
     Py_ssize_t ulen = PyList_GET_SIZE(st->unlock_chunks);
 
     if (st->context == VM_CTX_UNLOCK && st->program_counter >= ulen) {
+        /* Only the data stack survives the boundary. Everything else is
+           per-script in the TS/Go SDKs, so leaving it in place let an unlocking
+           script open a conditional, stash to the alt stack, or move the code
+           separator and have the locking script inherit it. */
+        if (st->if_stack.count != 0) {
+            vm_error(st, "Every OP_IF, OP_NOTIF, or OP_ELSE must be terminated with "
+                         "OP_ENDIF prior to the end of the unlocking script.");
+            return -1;
+        }
+        vms_free(&st->alt_stack);
+        st->last_code_separator = 0;
         st->context = VM_CTX_LOCK;
         st->program_counter = 0;
     }

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -80,6 +80,18 @@ class Spend:
         # If the context is UnlockingScript, and we have reached the end,
         # set the context to LockingScript and zero the program counter
         if self.context == "UnlockingScript" and self.program_counter >= len(self.unlocking_script.chunks):
+            # Only the data stack survives the boundary. Everything else is
+            # per-script in the TS/Go SDKs, so leaving it in place let an
+            # unlocking script open a conditional, stash to the alt stack, or
+            # move the code separator and have the locking script inherit it.
+            if self.if_stack:
+                self.script_evaluation_error(
+                    "Every OP_IF, OP_NOTIF, or OP_ELSE must be terminated with "
+                    "OP_ENDIF prior to the end of the unlocking script."
+                )
+            self.alt_stack = []
+            self.if_stack = []
+            self.last_code_separator = None
             self.context = "LockingScript"
             self.program_counter = 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_script_boundary_state.py
+++ b/tests/bsv/script/test_script_boundary_state.py
@@ -1,0 +1,69 @@
+"""Only the data stack crosses the unlocking→locking script boundary.
+
+The alt stack, the conditional stack and the code-separator position are all
+per-script in the TS SDK (`Spend.ts`) and the Go SDK (`interpreter/thread.go`),
+which also reject a conditional left open at the end of the unlocking script.
+"""
+
+import pytest
+
+from bsv.script.script import Script
+from bsv.script.spend import _USE_NATIVE_VM, Spend
+from bsv.transaction_output import TransactionOutput
+
+
+def _spend(locking_asm: str, unlocking_asm: str, tx_version: int = 2) -> Spend:
+    return Spend(
+        {
+            "sourceTXID": "00" * 32,
+            "sourceOutputIndex": 0,
+            "sourceSatoshis": 1000,
+            "lockingScript": Script.from_asm(locking_asm),
+            "transactionVersion": tx_version,
+            "otherInputs": [],
+            "outputs": [TransactionOutput(locking_script=Script(), satoshis=999)],
+            "inputIndex": 0,
+            "unlockingScript": Script.from_asm(unlocking_asm),
+            "inputSequence": 0xFFFFFFFF,
+            "lockTime": 0,
+        }
+    )
+
+
+def _run_both_paths(locking_asm: str, unlocking_asm: str) -> list:
+    results = [_spend(locking_asm, unlocking_asm)._validate_python()]
+    if _USE_NATIVE_VM:
+        results.append(_spend(locking_asm, unlocking_asm)._validate_native())
+    return results
+
+
+def _expect_rejected(locking_asm: str, unlocking_asm: str, match: str) -> None:
+    python_spend = _spend(locking_asm, unlocking_asm)
+    with pytest.raises(RuntimeError, match=match):
+        python_spend._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = _spend(locking_asm, unlocking_asm)
+        with pytest.raises(RuntimeError, match=match):
+            native_spend._validate_native()
+
+
+def test_alt_stack_does_not_cross_the_boundary():
+    # The unlocking script stashes a value; the locking script must not find it.
+    _expect_rejected("OP_FROMALTSTACK", "OP_1 OP_TOALTSTACK OP_1", "OP_FROMALTSTACK")
+
+
+def test_conditional_left_open_in_unlocking_script_is_rejected():
+    _expect_rejected("OP_ENDIF OP_1", "OP_1 OP_IF", "prior to the end of the unlocking script")
+
+
+def test_alt_stack_still_works_within_one_script():
+    assert all(_run_both_paths("OP_1 OP_TOALTSTACK OP_FROMALTSTACK", ""))
+
+
+def test_balanced_conditional_within_one_script_still_works():
+    assert all(_run_both_paths("OP_IF OP_1 OP_ELSE OP_0 OP_ENDIF", "OP_1"))
+
+
+def test_ordinary_unlocking_script_still_hands_over_the_data_stack():
+    # The data stack is the one thing that does cross.
+    assert all(_run_both_paths("OP_1 OP_EQUAL", "OP_1"))


### PR DESCRIPTION
## What

Only the data stack is meant to survive the unlocking→locking script boundary.
py-sdk switched context by setting `context` and `program_counter` and nothing
else, so three pieces of per-script state were inherited by the locking script:

| carried over | what an unlocking script could do |
|---|---|
| alt stack | stash a value with `OP_TOALTSTACK` for the locking script to `OP_FROMALTSTACK` |
| conditional stack | open an `OP_IF` and let the locking script close it |
| code-separator position | move it so the locking script signs a truncated subscript |

Confirmed against both references, which clear all three at the switch:

- **TS SDK** (`Spend.ts`): `clearAltStack()`, `ifStack = []`, `elseStack = []`,
  `lastCodeSeparator = null`
- **Go SDK** (`interpreter/thread.go`): `astack.DropN(astack.Depth())` under the
  comment *"Alt stack doesn't persist."*, and `lastCodeSep = 0`

Both also reject a conditional left open at the end of the unlocking script —
Go's comment is *"Illegal to have an `if' that straddles two scripts"*. py-sdk
only checked for unbalanced conditionals at the very end of `validate()`, by
which point the locking script had already executed with the inherited
conditional state.

Measured before the fix, on both VM paths:

| unlocking | locking | py-sdk | TS / Go |
|---|---|---|---|
| `OP_1 OP_TOALTSTACK OP_1` | `OP_FROMALTSTACK` | accepted | rejected |
| `OP_1 OP_IF` | `OP_ENDIF OP_1` | accepted | rejected |

## Fix

Clear the alt stack, the conditional stack and the code-separator position at
the boundary, and reject a still-open conditional there rather than at the end
of the run. Both VM paths shared the omission and are fixed together.

## Testing

New `tests/bsv/script/test_script_boundary_state.py`, every case run through
**both** VM paths:

- an alt-stack value does not cross the boundary
- a conditional left open in the unlocking script is rejected, naming the rule
- the alt stack still works within a single script
- a balanced conditional within a single script still works
- an ordinary unlocking script still hands the data stack over — the one thing
  that does cross

Verified the tests catch the bug rather than merely passing: 2 of 5 fail
against the unfixed code.

Full suite: 3784 passed, 262 skipped. black and ruff clean. No existing test
changed behaviour, so nothing in the repo depended on the inherited state.

## Related

Sixth PR from the script VM audit, after #197 (shift opcodes), #198
(`OP_SUBSTR` out-of-bounds read), #199 (`OP_DIV`/`OP_MOD` sign handling), #200
(`OP_CODESEPARATOR` subscript) and #201 (high-S signature parity). Still
outstanding from the audit: the `OP_VERIF`/`OP_RETURN`/`OP_ELSE` control-flow
divergences and the missing script-number length bound.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)