### PR TITLE
fix(script): bound script numbers by the Chronicle ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Security
+
+- **Script numbers are bounded by the Chronicle ceiling** — `bin2num` read an operand of any length, so nothing stopped a script from building a huge element and feeding it to the arithmetic: `OP_DUP OP_MUL` repeated in a ~100-byte script doubles the operand each time, reaching megabytes in a dozen rounds and gigabytes shortly after. The node rejects an over-long element in `CScriptNum`'s span constructor (`if(span.size() > max_length) throw scriptnum_overflow_error`) before the bytes reach any arithmetic, and py-sdk now does the same at 32 MiB on both VM paths. `Spend.bin2num` raises `ScriptNumberOverflow`, which the VM reports as a script evaluation error rather than letting it escape `validate()`.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2199,6 +2199,9 @@ static PyObject* pyfn_tx_preimage_otda(PyObject *self, PyObject *args) {
 /* ========================= Phase 3: Script VM ============================== */
 
 #define VM_MAX_ELEM_SIZE           (1024 * 1024 * 1024)
+/* Chronicle script-number ceiling, as returned by the node's
+   MaxScriptNumLength() for the post-Chronicle era. */
+#define VM_MAX_SCRIPT_NUM_LEN      (32 * 1024 * 1024)
 #define VM_STACK_INIT              64
 #define VM_IFSTACK_INIT            16
 #define VM_CTX_UNLOCK              0
@@ -2345,6 +2348,15 @@ static void ifs_free(IfStack *s) {
 
 static PyObject *c_bin2num(const unsigned char *data, Py_ssize_t len) {
     if (len == 0) return PyLong_FromLong(0);
+    /* The node rejects an over-long element before it becomes a number
+       (CScriptNum's span constructor), which is what keeps an arbitrarily wide
+       operand from reaching the arithmetic. */
+    if (len > VM_MAX_SCRIPT_NUM_LEN) {
+        /* Raised as a script error rather than a ValueError so both VM paths
+           fail the same way; vm_error is out of reach without the VMState. */
+        PyErr_SetString(PyExc_RuntimeError, "Script evaluation error: script number overflow");
+        return NULL;
+    }
     int negative = data[len - 1] & 0x80;
     if (len <= 8) {
         uint64_t val = 0;

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -17,7 +17,15 @@ try:
 except ImportError:
     _USE_NATIVE_VM = False
 
+
+class ScriptNumberOverflow(ValueError):
+    """A stack element is too wide to be read as a script number."""
+
+
 MAX_SCRIPT_ELEMENT_SIZE = 1024 * 1024 * 1024
+# Chronicle script-number ceiling, as returned by the node's
+# MaxScriptNumLength() for the post-Chronicle era.
+MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE = 32 * 1024 * 1024
 MAX_MULTISIG_KEY_COUNT = pow(2, 31) - 1
 REQUIRE_MINIMAL_PUSH = True
 REQUIRE_PUSH_ONLY_UNLOCKING_SCRIPTS = True
@@ -890,7 +898,11 @@ class Spend:
             self.script_evaluation_error("Unlocking scripts can only contain push operations, and no other opcodes.")
 
         while True:
-            self.step()
+            try:
+                self.step()
+            except ScriptNumberOverflow as e:
+                # bin2num is a classmethod and cannot raise a script error itself.
+                self.script_evaluation_error(str(e))
             if self.context == "LockingScript" and self.program_counter >= len(self.locking_script.chunks):
                 break
 
@@ -987,6 +999,11 @@ class Spend:
     def bin2num(cls, octets: bytes) -> int:
         if len(octets) == 0:
             return 0
+        # The node rejects an over-long element before it becomes a number
+        # (CScriptNum's span constructor), which is what keeps an arbitrarily
+        # wide operand from reaching the arithmetic.
+        if len(octets) > MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE:
+            raise ScriptNumberOverflow("script number overflow")
         negative = octets[-1] & 0x80
         octets = bytearray(octets)
         octets[-1] &= 0x7F

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_script_number_bound.py
+++ b/tests/bsv/script/test_script_number_bound.py
@@ -1,0 +1,67 @@
+"""A stack element wider than the script-number ceiling is not a number.
+
+The node rejects it in `CScriptNum`'s span constructor — `if(span.size() >
+max_length) throw scriptnum_overflow_error` — before the bytes reach any
+arithmetic, so the operand size is bounded by the rule rather than by whatever
+the script managed to build.
+"""
+
+import pytest
+
+from bsv.script.script import Script
+from bsv.script.spend import _USE_NATIVE_VM, MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE, Spend
+from bsv.transaction_output import TransactionOutput
+
+
+def _spend(locking_asm: str, tx_version: int = 2) -> Spend:
+    return Spend(
+        {
+            "sourceTXID": "00" * 32,
+            "sourceOutputIndex": 0,
+            "sourceSatoshis": 1000,
+            "lockingScript": Script.from_asm(locking_asm),
+            "transactionVersion": tx_version,
+            "otherInputs": [],
+            "outputs": [TransactionOutput(locking_script=Script(), satoshis=999)],
+            "inputIndex": 0,
+            "unlockingScript": Script(),
+            "inputSequence": 0xFFFFFFFF,
+            "lockTime": 0,
+        }
+    )
+
+
+def test_ceiling_matches_the_node():
+    # MaxScriptNumLength() for the post-Chronicle era.
+    assert MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE == 32 * 1024 * 1024
+
+
+def test_bin2num_rejects_an_oversized_element():
+    oversized = b"\x01" * (MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE + 1)
+    with pytest.raises(ValueError, match="script number overflow"):
+        Spend.bin2num(oversized)
+
+
+def test_bin2num_accepts_an_element_at_the_ceiling():
+    at_limit = b"\x01" * MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE
+    assert Spend.bin2num(at_limit) > 0
+
+
+@pytest.mark.parametrize("size", [1, 4, 8, 9, 64, 1000])
+def test_ordinary_operands_are_unaffected(size):
+    value = (1 << (size * 8 - 9)) if size > 1 else 1
+    assert Spend.bin2num(Spend.minimally_encode(value)) == value
+
+
+def test_oversized_operand_fails_the_script_not_the_interpreter():
+    # OP_NUM2BIN can build an element past the ceiling; reading it back as a
+    # number must be a script error on both paths, not a raw exception.
+    over = MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE + 1
+    asm = f"OP_1 {over.to_bytes(4, 'little').hex()} OP_NUM2BIN OP_1ADD OP_DROP OP_1"
+    python_spend = _spend(asm)
+    with pytest.raises(RuntimeError, match="script number overflow"):
+        python_spend._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = _spend(asm)
+        with pytest.raises(RuntimeError, match="script number overflow"):
+            native_spend._validate_native()


### PR DESCRIPTION
## What

`bin2num` read an operand of any length, so nothing stopped a script from
building a huge element and feeding it to the arithmetic. `OP_DUP OP_MUL`
repeated doubles the operand each round — a ~100-byte script reaches megabytes
in a dozen rounds and gigabytes shortly after, all inside a single script
evaluation.

The node rejects the element *before* it becomes a number, in `CScriptNum`'s
span constructor (`src/script/script_num.cpp`):

```cpp
if(span.size() > max_length)
    throw scriptnum_overflow_error("script number overflow");
```

with `max_length = MaxScriptNumLength()` for the era — 32 MiB post-Chronicle,
per BDK's `GetMaxScriptNumLength(isGenesisEnabled, isChronicleEnabled, ...)`.
py-sdk had no such check at all: `MAX_SCRIPT_NUMBER_LENGTH_AFTER_CHRONICLE`
existed only to derive an unrelated constant.

## Fix

Apply the same 32 MiB bound when reading an operand, on both VM paths.

`Spend.bin2num` is a classmethod and cannot raise a script error itself, so it
raises `ScriptNumberOverflow` and the VM loop converts it. Otherwise a
`ValueError` would escape `Spend.validate()` — the same failure mode already
fixed for `OP_NUM2BIN` in #199. The C extension raises the script error
directly, since `vm_error` needs a `VMState` that `c_bin2num` does not have.

## Testing

New `tests/bsv/script/test_script_number_bound.py`:

- the ceiling matches the node's post-Chronicle `MaxScriptNumLength()`
- an element one byte over is rejected; one exactly at the ceiling is accepted
- ordinary operands from 1 to 1000 bytes round-trip unchanged
- an oversized operand built with `OP_NUM2BIN` fails as a *script* error on
  both VM paths, not as a raw exception

Verified the check is actually consulted rather than incidentally satisfied:
lowering the ceiling to 4 in-process rejects a 5-byte element and accepts a
4-byte one, and restoring it accepts the 5-byte element again.

Full suite: 3789 passed, 262 skipped. black and ruff clean.

## Scope

This is the length bound only. The node also enforces *minimal encoding* on
numeric operands when `SCRIPT_VERIFY_MINIMALDATA` is set
(`if(!IsMinimallyEncoded(span, max_length)) throw scriptnum_minencode_error`),
which py-sdk applies to pushes but not to numeric reads. That is a separate
behavioural change with its own vector implications, so it is left out here.

## Related

Eighth PR from the script VM audit, after #197 (shift opcodes), #198
(`OP_SUBSTR` out-of-bounds read), #199 (`OP_DIV`/`OP_MOD` sign handling), #200
(`OP_CODESEPARATOR` subscript), #201 (high-S signature parity), #202 (VM state
at the script boundary) and #203 (`OP_VERIF` in a skipped branch, `OP_ELSE`
grammar). The remaining audit item is `OP_RETURN` inside a conditional, which
touches the same boundary block as #202 and follows once that merges.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)