### PR TITLE
fix(script): enforce NULLFAIL for OP_CHECKMULTISIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **`OP_CHECKMULTISIG` now enforces NULLFAIL** — a failed signature check requires the signature to be the empty vector, which py-sdk applied to `OP_CHECKSIG` but not to `OP_CHECKMULTISIG`. The node applies it to both, in the multisig cleanup loop (`if (!fSuccess && VerifyNullFail(flags) && !ikey2 && !vchSig.empty())`), so a transaction the node rejects as malleable validated here. Chronicle relaxes it for transaction version > 1 exactly as it does for `OP_CHECKSIG`, and both VM paths now agree.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -3853,6 +3853,16 @@ static int vm_step(VMState *st) {
 
         /* Clean up stack of actual arguments */
         while (ii > 1) {
+            /* NULLFAIL: once the keys are exhausted the remaining items are the
+               signatures, and a failed check requires every one of them to be
+               empty. Chronicle relaxes this for tx version > 1, as for CHECKSIG. */
+            if (!f && !(st->tx_version > 1) && i_key2 == 0) {
+                StackElem *sig_top = vms_top(&st->stack, -1);
+                if (sig_top && sig_top->len > 0) {
+                    vm_errorf(st, "%s requires a failed signature to be the empty vector.", name);
+                    return -1;
+                }
+            }
             if (i_key2 > 0) i_key2--;
             vms_pop(&st->stack, NULL);
             ii--;

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -722,6 +722,12 @@ class Spend:
 
                 # Clean up stack of actual arguments
                 while i > 1:
+                    # NULLFAIL: once the keys are exhausted the remaining items
+                    # are the signatures, and a failed check requires every one
+                    # of them to be empty. Chronicle relaxes this for
+                    # transaction version > 1, as it does for OP_CHECKSIG.
+                    if not f and not self.is_relaxed() and i_key2 == 0 and len(self.stacktop(-1)) > 0:
+                        self.script_evaluation_error(f"{_codename} requires a failed signature to be the empty vector.")
                     if i_key2 > 0:
                         i_key2 -= 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_checkmultisig_nullfail.py
+++ b/tests/bsv/script/test_checkmultisig_nullfail.py
@@ -1,0 +1,108 @@
+"""A failed OP_CHECKMULTISIG requires its signatures to be the empty vector.
+
+The node applies NULLFAIL to `OP_CHECKMULTISIG` exactly as it does to
+`OP_CHECKSIG` — `if (!fSuccess && VerifyNullFail(flags) && !ikey2 &&
+!vchSig.empty())` in the cleanup loop, guarded by `EnforceNonMalleability`,
+which Chronicle relaxes for transaction version > 1. py-sdk enforced it for
+`OP_CHECKSIG` only.
+"""
+
+import pytest
+
+from bsv.constants import SIGHASH, OpCode
+from bsv.keys import PrivateKey
+from bsv.script.script import Script
+from bsv.script.spend import _USE_NATIVE_VM, Spend
+from bsv.transaction_input import TransactionInput
+from bsv.transaction_output import TransactionOutput
+from bsv.transaction_preimage import tx_preimage
+from bsv.utils import encode_pushdata
+
+SOURCE_TXID = "33" * 32
+SOURCE_SATOSHIS = 10_000
+SIGHASH_FLAG = SIGHASH.ALL_FORKID
+
+
+@pytest.fixture
+def priv_key():
+    return PrivateKey()
+
+
+def _outputs():
+    return [TransactionOutput(locking_script=Script.from_asm("OP_TRUE"), satoshis=9_000)]
+
+
+def _locking_1_of_1_that_fails() -> Script:
+    """1-of-1 multisig against an unrelated key, so the check always fails.
+
+    OP_NOT turns the FALSE into TRUE, so the script would otherwise succeed and
+    only NULLFAIL decides the outcome.
+    """
+    other_pub = PrivateKey().public_key().serialize()
+    return Script(OpCode.OP_1 + encode_pushdata(other_pub) + OpCode.OP_1 + OpCode.OP_CHECKMULTISIG + OpCode.OP_NOT)
+
+
+def _unlocking(priv_key, locking: Script, tx_version: int, empty_sig: bool) -> Script:
+    # OP_0 is the dummy element CHECKMULTISIG consumes.
+    if empty_sig:
+        return Script(OpCode.OP_0 + OpCode.OP_0)
+    inp = TransactionInput(
+        source_txid=SOURCE_TXID,
+        source_output_index=0,
+        unlocking_script=Script(),
+        sequence=0xFFFFFFFF,
+        sighash=SIGHASH_FLAG,
+    )
+    inp.locking_script = locking
+    inp.satoshis = SOURCE_SATOSHIS
+    sig = priv_key.sign(tx_preimage(0, [inp], _outputs(), tx_version, 0))
+    return Script(OpCode.OP_0 + encode_pushdata(sig + SIGHASH_FLAG.to_bytes(1, "little")))
+
+
+def _spend(locking: Script, unlocking: Script, tx_version: int) -> Spend:
+    return Spend(
+        {
+            "sourceTXID": SOURCE_TXID,
+            "sourceOutputIndex": 0,
+            "sourceSatoshis": SOURCE_SATOSHIS,
+            "lockingScript": locking,
+            "transactionVersion": tx_version,
+            "otherInputs": [],
+            "outputs": _outputs(),
+            "inputIndex": 0,
+            "unlockingScript": unlocking,
+            "inputSequence": 0xFFFFFFFF,
+            "lockTime": 0,
+        }
+    )
+
+
+def _results(priv_key, tx_version: int, empty_sig: bool) -> list:
+    locking = _locking_1_of_1_that_fails()
+    unlocking = _unlocking(priv_key, locking, tx_version, empty_sig)
+    out = []
+    for use_native in (False, True):
+        if use_native and not _USE_NATIVE_VM:
+            continue
+        spend = _spend(locking, unlocking, tx_version)
+        try:
+            out.append(spend._validate_native() if use_native else spend._validate_python())
+        except RuntimeError as e:
+            out.append(str(e))
+    return out
+
+
+def test_strict_version_rejects_a_nonempty_failed_signature(priv_key):
+    for result in _results(priv_key, tx_version=1, empty_sig=False):
+        assert isinstance(result, str), result
+        assert "empty vector" in result, result
+
+
+def test_strict_version_accepts_an_empty_failed_signature(priv_key):
+    # The same script with the empty vector is how a failed slot is spelled.
+    assert _results(priv_key, tx_version=1, empty_sig=True) == [True] * (2 if _USE_NATIVE_VM else 1)
+
+
+def test_relaxed_version_allows_a_nonempty_failed_signature(priv_key):
+    # Chronicle relaxes NULLFAIL for version > 1, as it does for OP_CHECKSIG.
+    assert _results(priv_key, tx_version=2, empty_sig=False) == [True] * (2 if _USE_NATIVE_VM else 1)


### PR DESCRIPTION
## What

NULLFAIL requires that when a signature check fails, the signature was the empty
vector — otherwise the spender could have swapped in any garbage and the
transaction stays malleable.

py-sdk applied it to `OP_CHECKSIG` and not to `OP_CHECKMULTISIG`, so the two
opcodes disagreed with each other, and a transaction the node rejects validated
here.

The node applies it to both. In the multisig cleanup loop
(`src/script/interpreter.cpp`):

```cpp
const auto& vchSig { stack.stacktop(-1) };
if (!fSuccess && VerifyNullFail(flags) && !ikey2 && !vchSig.empty())
{
    if(EnforceNonMalleability(flags, checker.Version()))
    {
        return SCRIPT_ERR_SIG_NULLFAIL;
    }
}
```

which is the same shape as its `OP_CHECKSIG` counterpart a hundred lines
earlier.

## Fix

The check goes in the same place, with both of the node's conditions:

- `!ikey2` scopes it to the signature slots rather than the keys still being
  consumed
- `EnforceNonMalleability(flags, checker.Version())` is the Chronicle
  relaxation — transaction version > 1 skips it, exactly as py-sdk already does
  for `OP_CHECKSIG` via `is_relaxed()`

Both VM paths.

## Testing

New `tests/bsv/script/test_checkmultisig_nullfail.py`, through **both** VM
paths. The locking script is a 1-of-1 multisig against an unrelated key so the
check always fails, followed by `OP_NOT` — the script would otherwise succeed,
so NULLFAIL alone decides the outcome:

- version 1 rejects a non-empty signature on the failed check
- version 1 accepts the empty vector, which is how a failed slot is spelled
- version 2 allows the non-empty signature, matching the relaxation already
  covered for `OP_CHECKSIG` in `test_live_malleability.py`

Verified the test catches the bug rather than merely passing: the version-1
rejection fails against the unfixed code, while the other two already held.

Full suite: 3782 passed, 262 skipped. black and ruff clean. No existing test
changed behaviour.

## Related

From the script VM audit, after #197 through #205. This one came out of the
audit's note that py-sdk had NULLFAIL on one of the two opcodes; the node
settled which way to close the gap.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)