### PR TITLE
fix(script): require minimal encoding for numeric operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [2.3.3 - 2026-07-23](#233---2026-07-23)
 - [2.3.1 - 2026-07-22](#231---2026-07-22)
 - [2.3.0 - 2026-07-21](#230---2026-07-21)
@@ -34,6 +35,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - [1.0.0 - 2024-12-23](#100---2024-12-23)
 - [0.5.2 - 2024-09-02](#052---2024-09-02)
 - [0.1.0 - 2024-04-09](#010---2024-04-09)
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **Numeric operands must be minimally encoded where minimal pushes are** — the node derives one `requireMinimal` from `VerifyMinimalData(flags) && EnforceNonMalleability(flags, version)` and uses it both for `CheckMinimalPush` and for every `CScriptNum` construction. py-sdk applied it to pushes only, so `0x0100` — a minimal *push* but a non-minimal *number* for 1 — was accepted as an operand where the node rejects it, as was negative zero (`0x80`). Now enforced on both VM paths, and relaxed for transaction version > 1 alongside minimal pushes. `OP_BIN2NUM` is deliberately exempt: minimising a non-minimal encoding is what it is for, and the node reads its input directly rather than through `CScriptNum`.
 
 ---
 

--- a/_bsv_native/bsv_native.c
+++ b/_bsv_native/bsv_native.c
@@ -2343,6 +2343,18 @@ static void ifs_free(IfStack *s) {
 
 /* --- Script number helpers ---------------------------------------------- */
 
+/* Defined below, alongside the other VM error helpers. */
+static void vm_error(VMState *st, const char *msg);
+
+/* Whether an element is the shortest encoding of its value: a zero
+   most-significant byte (sign bit aside) is redundant unless the byte below it
+   needs the extra room for its own sign bit. */
+static int c_is_minimal_num(const unsigned char *data, Py_ssize_t len) {
+    if (len == 0) return 1;
+    if ((data[len - 1] & 0x7F) == 0 && (len <= 1 || (data[len - 2] & 0x80) == 0)) return 0;
+    return 1;
+}
+
 static PyObject *c_bin2num(const unsigned char *data, Py_ssize_t len) {
     if (len == 0) return PyLong_FromLong(0);
     int negative = data[len - 1] & 0x80;
@@ -2414,17 +2426,30 @@ static int vms_push_num(VmStack *s, PyObject *num) {
     return rc;
 }
 
-static PyObject *vms_pop_num(VmStack *s) {
+/* Reads a numeric operand under the era's rules. The node gates minimal
+   encoding on the same flag as minimal pushes and relaxes both together after
+   Chronicle, so this mirrors the tx_version test used for pushes. */
+static PyObject *vms_pop_num(VMState *st) {
     StackElem e = {0};
-    if (vms_pop(s, &e) < 0) return NULL;
+    if (vms_pop(&st->stack, &e) < 0) return NULL;
+    if (!(st->tx_version > 1) && !c_is_minimal_num(e.data, e.len)) {
+        se_free(&e);
+        vm_error(st, "non-minimally encoded script number");
+        return NULL;
+    }
     PyObject *n = c_bin2num(e.data, e.len);
     se_free(&e);
     return n;
 }
 
-static PyObject *vms_remove_num(VmStack *s, Py_ssize_t idx) {
+static PyObject *vms_remove_num(VMState *st, Py_ssize_t idx) {
     StackElem e = {0};
-    if (vms_remove(s, idx, &e) < 0) return NULL;
+    if (vms_remove(&st->stack, idx, &e) < 0) return NULL;
+    if (!(st->tx_version > 1) && !c_is_minimal_num(e.data, e.len)) {
+        se_free(&e);
+        vm_error(st, "non-minimally encoded script number");
+        return NULL;
+    }
     PyObject *n = c_bin2num(e.data, e.len);
     se_free(&e);
     return n;
@@ -3410,7 +3435,7 @@ static int vm_step(VMState *st) {
             vm_errorf(st, "%s requires at least one items to be on the stack.", name);
             return -1;
         }
-        PyObject *x = vms_pop_num(&st->stack);
+        PyObject *x = vms_pop_num(st);
         if (!x) return -1;
         PyObject *r = NULL;
         switch (op) {
@@ -3439,7 +3464,7 @@ static int vm_step(VMState *st) {
             vm_errorf(st, "%s requires at least one item to be on the stack.", name);
             return -1;
         }
-        PyObject *x = vms_pop_num(&st->stack);
+        PyObject *x = vms_pop_num(st);
         if (!x) return -1;
         PyObject *two = PyLong_FromLong(2);
         PyObject *r = NULL;
@@ -3472,8 +3497,8 @@ static int vm_step(VMState *st) {
             vm_errorf(st, "%s requires at least two items on the stack.", name);
             return -1;
         }
-        PyObject *shift = vms_pop_num(&st->stack);
-        PyObject *value = vms_pop_num(&st->stack);
+        PyObject *shift = vms_pop_num(st);
+        PyObject *value = vms_pop_num(st);
         if (!shift || !value) {
             Py_XDECREF(shift); Py_XDECREF(value); return -1;
         }
@@ -3516,8 +3541,8 @@ static int vm_step(VMState *st) {
             vm_errorf(st, "%s requires at least two items to be on the stack.", name);
             return -1;
         }
-        PyObject *x1 = vms_remove_num(&st->stack, st->stack.count - 2);
-        PyObject *x2 = vms_pop_num(&st->stack);
+        PyObject *x1 = vms_remove_num(st, st->stack.count - 2);
+        PyObject *x2 = vms_pop_num(st);
         if (!x1 || !x2) {
             Py_XDECREF(x1); Py_XDECREF(x2); return -1;
         }
@@ -3605,9 +3630,9 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_WITHIN requires at least three items to be on the stack.");
             return -1;
         }
-        PyObject *x1 = vms_remove_num(&st->stack, st->stack.count - 3);
-        PyObject *x2 = vms_remove_num(&st->stack, st->stack.count - 2);
-        PyObject *x3 = vms_pop_num(&st->stack);
+        PyObject *x1 = vms_remove_num(st, st->stack.count - 3);
+        PyObject *x2 = vms_remove_num(st, st->stack.count - 2);
+        PyObject *x3 = vms_pop_num(st);
         if (!x1 || !x2 || !x3) {
             Py_XDECREF(x1); Py_XDECREF(x2); Py_XDECREF(x3); return -1;
         }
@@ -3925,7 +3950,7 @@ static int vm_step(VMState *st) {
         }
         StackElem x1 = {0};
         vms_remove(&st->stack, st->stack.count - 2, &x1);
-        PyObject *nobj = vms_pop_num(&st->stack);
+        PyObject *nobj = vms_pop_num(st);
         if (!nobj) { se_free(&x1); return -1; }
         long long n = PyLong_AsLongLong(nobj);
         Py_DECREF(nobj);
@@ -3948,8 +3973,8 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_SUBSTR requires at least three items on the stack.");
             return -1;
         }
-        PyObject *lobj = vms_pop_num(&st->stack);
-        PyObject *sobj = vms_pop_num(&st->stack);
+        PyObject *lobj = vms_pop_num(st);
+        PyObject *sobj = vms_pop_num(st);
         StackElem dat = {0}; vms_pop(&st->stack, &dat);
         if (!lobj || !sobj) {
             Py_XDECREF(lobj); Py_XDECREF(sobj); se_free(&dat); return -1;
@@ -3981,7 +4006,7 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_LEFT requires at least two items on the stack.");
             return -1;
         }
-        PyObject *lobj = vms_pop_num(&st->stack);
+        PyObject *lobj = vms_pop_num(st);
         StackElem dat = {0}; vms_pop(&st->stack, &dat);
         if (!lobj) { se_free(&dat); return -1; }
         long long length = PyLong_AsLongLong(lobj);
@@ -4001,7 +4026,7 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_RIGHT requires at least two items on the stack.");
             return -1;
         }
-        PyObject *lobj = vms_pop_num(&st->stack);
+        PyObject *lobj = vms_pop_num(st);
         StackElem dat = {0}; vms_pop(&st->stack, &dat);
         if (!lobj) { se_free(&dat); return -1; }
         long long length = PyLong_AsLongLong(lobj);
@@ -4023,7 +4048,7 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_NUM2BIN requires at least two items to be on the stack.");
             return -1;
         }
-        PyObject *sobj = vms_pop_num(&st->stack);
+        PyObject *sobj = vms_pop_num(st);
         if (!sobj) return -1;
         long long size = PyLong_AsLongLong(sobj);
         Py_DECREF(sobj);
@@ -4033,7 +4058,7 @@ static int vm_step(VMState *st) {
                       VM_MAX_ELEM_SIZE);
             return -1;
         }
-        PyObject *n = vms_pop_num(&st->stack);
+        PyObject *n = vms_pop_num(st);
         if (!n) return -1;
         unsigned char *me; Py_ssize_t me_len;
         if (c_min_encode(n, &me, &me_len) < 0) { Py_DECREF(n); return -1; }
@@ -4066,7 +4091,12 @@ static int vm_step(VMState *st) {
             vm_error(st, "OP_BIN2NUM requires at least one item to be on the stack.");
             return -1;
         }
-        PyObject *x = vms_pop_num(&st->stack);
+        /* Reads the element directly: minimising a non-minimal encoding is what
+           this opcode is for, so requiring one on input would defeat it. */
+        StackElem raw = {0};
+        if (vms_pop(&st->stack, &raw) < 0) return -1;
+        PyObject *x = c_bin2num(raw.data, raw.len);
+        se_free(&raw);
         if (!x) return -1;
         int rc = vms_push_num(&st->stack, x);
         Py_DECREF(x);

--- a/bsv/script/spend.py
+++ b/bsv/script/spend.py
@@ -365,7 +365,7 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 2:
                     self.script_evaluation_error(f"{_codename} requires at least two items to be on the stack.")
-                n = self.bin2num(self.stacktop(-1))
+                n = self.read_script_number(self.stacktop(-1))
                 self.stack.pop()
                 if n < 0 or n >= len(self.stack):
                     _m = (
@@ -440,7 +440,7 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 2:
                     self.script_evaluation_error(f"{_codename} requires at least two items to be on the stack.")
-                n = self.bin2num(self.stacktop(-1))
+                n = self.read_script_number(self.stacktop(-1))
                 if n < 0:
                     self.script_evaluation_error(f"{_codename} requires the top stack item to be non-negative.")
                 x = self.stack.pop(-2)
@@ -475,7 +475,7 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 1:
                     self.script_evaluation_error(f"{_codename} requires at least one items to be on the stack.")
-                x = self.bin2num(self.stack.pop())
+                x = self.read_script_number(self.stack.pop())
                 if current_opcode == OpCode.OP_1ADD:
                     x += 1
                 elif current_opcode == OpCode.OP_1SUB:
@@ -494,7 +494,7 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 1:
                     self.script_evaluation_error(f"{_codename} requires at least one item to be on the stack.")
-                x = self.bin2num(self.stack.pop())
+                x = self.read_script_number(self.stack.pop())
                 if current_opcode == OpCode.OP_2MUL:
                     x = x * 2
                 else:
@@ -506,8 +506,8 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 2:
                     self.script_evaluation_error(f"{_codename} requires at least two items on the stack.")
-                shift = self.bin2num(self.stack.pop())
-                value = self.bin2num(self.stack.pop())
+                shift = self.read_script_number(self.stack.pop())
+                value = self.read_script_number(self.stack.pop())
                 if shift < 0:
                     self.script_evaluation_error(f"{_codename}: shift amount must be non-negative.")
                 if current_opcode == OpCode.OP_LSHIFTNUM:
@@ -540,8 +540,8 @@ class Spend:
                 _codename = OPCODE_VALUE_NAME_DICT[current_opcode]
                 if len(self.stack) < 2:
                     self.script_evaluation_error(f"{_codename} requires at least two items to be on the stack.")
-                x1 = self.bin2num(self.stack.pop(-2))
-                x2 = self.bin2num(self.stack.pop())
+                x1 = self.read_script_number(self.stack.pop(-2))
+                x2 = self.read_script_number(self.stack.pop())
                 if current_opcode == OpCode.OP_ADD:
                     x = x1 + x2
                 elif current_opcode == OpCode.OP_SUB:
@@ -587,9 +587,9 @@ class Spend:
             elif current_opcode == OpCode.OP_WITHIN:
                 if len(self.stack) < 3:
                     self.script_evaluation_error("OP_WITHIN requires at least three items to be on the stack.")
-                x1 = self.bin2num(self.stack.pop(-3))
-                x2 = self.bin2num(self.stack.pop(-2))
-                x3 = self.bin2num(self.stack.pop())
+                x1 = self.read_script_number(self.stack.pop(-3))
+                x2 = self.read_script_number(self.stack.pop(-2))
+                x3 = self.read_script_number(self.stack.pop())
                 f = x2 <= x1 < x3
                 self.stack.append(self.encode_bool(f))
 
@@ -659,7 +659,7 @@ class Spend:
                 if len(self.stack) < i:
                     self.script_evaluation_error(f"{_codename} requires at least 1 item to be on the stack.")
 
-                keys_count = self.bin2num(self.stacktop(-i))
+                keys_count = self.read_script_number(self.stacktop(-i))
                 if keys_count < 0 or keys_count > MAX_MULTISIG_KEY_COUNT:
                     _m = f"${_codename} requires a key count between 0 and {MAX_MULTISIG_KEY_COUNT}."
                     self.script_evaluation_error(_m)
@@ -675,7 +675,7 @@ class Spend:
                     _m = f"{_codename} requires the number of stack items not to be less than the number of keys used."
                     self.script_evaluation_error(_m)
 
-                sigs_count = self.bin2num(self.stacktop(-i))
+                sigs_count = self.read_script_number(self.stacktop(-i))
                 if sigs_count < 0 or sigs_count > keys_count:
                     _m = f"{_codename} requires the number of signatures to be no greater than the number of keys."
                     self.script_evaluation_error(_m)
@@ -764,7 +764,7 @@ class Spend:
                     self.script_evaluation_error("OP_SPLIT requires at least two items to be on the stack.")
                 x1 = self.stack.pop(-2)
                 #  Make sure the split point is appropriate.
-                n = self.bin2num(self.stack.pop())
+                n = self.read_script_number(self.stack.pop())
                 if n < 0 or n > len(x1):
                     self.script_evaluation_error(
                         "OP_SPLIT requires the first stack item to be a non-negative number "
@@ -776,8 +776,8 @@ class Spend:
             elif current_opcode == OpCode.OP_SUBSTR:
                 if len(self.stack) < 3:
                     self.script_evaluation_error("OP_SUBSTR requires at least three items on the stack.")
-                length = self.bin2num(self.stack.pop())
-                start = self.bin2num(self.stack.pop())
+                length = self.read_script_number(self.stack.pop())
+                start = self.read_script_number(self.stack.pop())
                 data = self.stack.pop()
                 if len(data) == 0:
                     self.script_evaluation_error("OP_SUBSTR: source string is empty.")
@@ -790,7 +790,7 @@ class Spend:
             elif current_opcode == OpCode.OP_LEFT:
                 if len(self.stack) < 2:
                     self.script_evaluation_error("OP_LEFT requires at least two items on the stack.")
-                length = self.bin2num(self.stack.pop())
+                length = self.read_script_number(self.stack.pop())
                 data = self.stack.pop()
                 if length < 0 or length > len(data):
                     self.script_evaluation_error("OP_LEFT: length out of range.")
@@ -799,7 +799,7 @@ class Spend:
             elif current_opcode == OpCode.OP_RIGHT:
                 if len(self.stack) < 2:
                     self.script_evaluation_error("OP_RIGHT requires at least two items on the stack.")
-                length = self.bin2num(self.stack.pop())
+                length = self.read_script_number(self.stack.pop())
                 data = self.stack.pop()
                 if length < 0 or length > len(data):
                     self.script_evaluation_error("OP_RIGHT: length out of range.")
@@ -808,12 +808,12 @@ class Spend:
             elif current_opcode == OpCode.OP_NUM2BIN:
                 if len(self.stack) < 2:
                     self.script_evaluation_error("OP_NUM2BIN requires at least two items to be on the stack.")
-                size = self.bin2num(self.stack.pop())
+                size = self.read_script_number(self.stack.pop())
                 if size > MAX_SCRIPT_ELEMENT_SIZE:
                     self.script_evaluation_error(
                         f"It's not currently possible to push data larger than {MAX_SCRIPT_ELEMENT_SIZE} bytes."
                     )
-                n = self.bin2num(self.stack.pop())
+                n = self.read_script_number(self.stack.pop())
                 x = bytearray(self.minimally_encode(n))
 
                 # Try to see if we can fit that number in the number of byte requested.
@@ -982,6 +982,28 @@ class Spend:
         if negative:
             octets[-1] |= 0x80
         return octets
+
+    @staticmethod
+    def is_minimally_encoded_number(octets: bytes) -> bool:
+        """Whether an element is the shortest encoding of its value."""
+        if len(octets) == 0:
+            return True
+        # A zero most-significant byte (sign bit aside) is redundant unless the
+        # byte below it needs the extra room for its own sign bit.
+        if (octets[-1] & 0x7F) == 0 and (len(octets) <= 1 or (octets[-2] & 0x80) == 0):
+            return False
+        return True
+
+    def read_script_number(self, octets: bytes) -> int:
+        """Read a stack element as a numeric operand under the era's rules.
+
+        The node gates this on the same flag as minimal pushes and relaxes both
+        together after Chronicle, so a non-minimal number is only an error where
+        a non-minimal push would be.
+        """
+        if not self.is_relaxed() and REQUIRE_MINIMAL_PUSH and not self.is_minimally_encoded_number(octets):
+            self.script_evaluation_error("non-minimally encoded script number")
+        return self.bin2num(octets)
 
     @classmethod
     def bin2num(cls, octets: bytes) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
 ]
 dev = [
     "black>=26.0.0",
-    "ruff>=0.15.0",
+    "ruff>=0.16.0",
 ]
 
 [build-system]
@@ -101,6 +101,7 @@ ignore = [
     "E501",     # line-too-long (handled by black formatter)
     "PLC0415",  # import-not-at-top-level (acceptable for conditional imports)
     "PLR0913",  # too-many-arguments (some functions legitimately need many args)
+    "PLR0917",  # too-many-positional-arguments (ruff 0.16 default, mirrors PLR0913)
     "SIM117",   # nested-with-statements (acceptable in test code)
     "N802",     # function-name-should-be-lowercase (test function naming conventions)
     "N806",     # variable-name-should-be-lowercase (constants and class attributes)

--- a/tests/bsv/script/test_minimal_number_encoding.py
+++ b/tests/bsv/script/test_minimal_number_encoding.py
@@ -1,0 +1,76 @@
+"""Numeric operands must be minimally encoded where minimal pushes are.
+
+The node derives one `requireMinimal` from `VerifyMinimalData(flags) &&
+EnforceNonMalleability(flags, version)` and uses it for both `CheckMinimalPush`
+and every `CScriptNum` construction. py-sdk applied it to pushes only, so
+`0x0100` — a minimal *push* but a non-minimal *number* for 1 — was accepted as
+an operand where the node rejects it.
+"""
+
+import pytest
+
+from bsv.script.spend import _USE_NATIVE_VM, Spend
+
+from .conftest import make_spend
+
+
+def _accepted(locking_asm: str, tx_version: int) -> bool:
+    """True when both VM paths accept; asserts they agree."""
+    results = [make_spend(locking_asm, tx_version=tx_version)._validate_python()]
+    if _USE_NATIVE_VM:
+        results.append(make_spend(locking_asm, tx_version=tx_version)._validate_native())
+    assert len(set(results)) == 1, results
+    return results[0]
+
+
+def _rejected(locking_asm: str, tx_version: int) -> None:
+    python_spend = make_spend(locking_asm, tx_version=tx_version)
+    with pytest.raises(RuntimeError, match="non-minimally encoded script number"):
+        python_spend._validate_python()
+    if _USE_NATIVE_VM:
+        native_spend = make_spend(locking_asm, tx_version=tx_version)
+        with pytest.raises(RuntimeError, match="non-minimally encoded script number"):
+            native_spend._validate_native()
+
+
+@pytest.mark.parametrize(
+    "octets,minimal",
+    [
+        (b"", True),
+        (b"\x01", True),
+        (b"\x81", True),  # -1
+        (b"\x80", False),  # negative zero
+        (b"\x00", False),  # padded zero
+        (b"\x01\x00", False),  # 1 with a redundant high byte
+        (b"\x00\x80", False),
+        (b"\x80\x00", True),  # 128 needs the extra byte for its sign bit
+        (b"\xff\x00", True),
+        (b"\x01\x00\x00", False),
+    ],
+)
+def test_minimality_predicate(octets, minimal):
+    assert Spend.is_minimally_encoded_number(octets) is minimal
+
+
+def test_non_minimal_operand_is_rejected_when_strict():
+    # 0x0100 is 1 with a redundant high byte: a minimal push, not a minimal number.
+    _rejected("0100 OP_1ADD OP_2 OP_NUMEQUAL", tx_version=1)
+
+
+def test_negative_zero_operand_is_rejected_when_strict():
+    _rejected("80 OP_NOT OP_1 OP_NUMEQUAL", tx_version=1)
+
+
+def test_non_minimal_operand_is_allowed_when_relaxed():
+    # Chronicle relaxes this together with minimal pushes, for version > 1.
+    assert _accepted("0100 OP_1ADD OP_2 OP_NUMEQUAL", tx_version=2)
+
+
+def test_minimal_operand_is_unaffected():
+    assert _accepted("OP_1 OP_1ADD OP_2 OP_NUMEQUAL", tx_version=1)
+
+
+def test_op_bin2num_still_accepts_a_non_minimal_input():
+    # Minimising a non-minimal encoding is what the opcode is for, so the node
+    # reads the element directly instead of through CScriptNum.
+    assert _accepted("0100 OP_BIN2NUM OP_1 OP_NUMEQUAL", tx_version=1)


### PR DESCRIPTION
## What

The node derives a single flag and uses it in two places:

```cpp
const auto requireMinimal { VerifyMinimalData(flags) &&
                            EnforceNonMalleability(flags, checker.Version()) ? ... }
...
if((requireMinimal == min_encoding_check::yes) && !CheckMinimalPush(vchPushValue, opcode))   // pushes
...
const CScriptNum bn(stack.stacktop(-1).GetElement(), requireMinimal, max_len);               // operands
```

py-sdk applied it to pushes only. So an element that is a minimal *push* but a
non-minimal *number* passed as an operand:

| script (version 1) | py-sdk (before) | node |
|---|---|---|
| `0x0100 OP_1ADD OP_2 OP_NUMEQUAL` | accepted | rejected — `0x0100` is 1 with a redundant high byte |
| `0x80 OP_NOT OP_1 OP_NUMEQUAL` | accepted | rejected — negative zero |

## Fix

Numeric reads in the VM go through a new `read_script_number`, which applies the
same era test py-sdk already used for pushes, so the two relax together after
Chronicle (version > 1). The C extension puts the check in the `vms_pop_num` /
`vms_remove_num` wrappers, which now take the `VMState` so they can see
`tx_version` — that covers every numeric read without threading a flag through
each call site.

### `OP_BIN2NUM` is exempt

Deliberately, on both paths. Minimising a non-minimal encoding is the whole
point of the opcode, and the node reads its element directly rather than
through `CScriptNum`:

```cpp
LimitedVector &n = stack.stacktop(-1);
n.MinimallyEncode();
// The resulting number must be a valid number.
if(!n.IsMinimallyEncoded(params.MaxScriptNumLength()))
    return SCRIPT_ERR_INVALID_NUMBER_RANGE;
```

It checks the *result*, not the input. Blanket-applying the operand rule here
would have made the opcode unable to do its job.

## Testing

New `tests/bsv/script/test_minimal_number_encoding.py`, every script case
through **both** VM paths, asserting the two agree:

- 10 cases pinning the minimality predicate, including `0x80\x00` (128, which
  genuinely needs the extra byte for its sign bit) and negative zero
- a non-minimal operand and a negative zero are rejected at version 1
- the same operand is allowed at version 2
- a minimal operand is unaffected
- `OP_BIN2NUM` still accepts a non-minimal input

### Impact measured before implementing

Instrumented `bin2num` across the whole suite: **zero** non-minimally-encoded
elements are read by any of the 3794 tests, including the 229 Bitcoin Core
vectors. So unlike the `OP_ELSE` grammar in #203, this needed no vectors
reclassified — nothing in the repo depended on the permissive behaviour.

Full suite: 3794 passed, 262 skipped. black and ruff clean.

## Related

From the script VM audit, after #197 through #206. This closes the last item the
audit turned up.

## Note on the PLR0917 commit

`ruff>=0.15.0` is unpinned and now resolves to 0.16.0, which enables PLR0917 and
reports 41 pre-existing findings — any branch off master fails CI on them. #190
already fixes this, so its suppression commit is cherry-picked here to keep this
branch independently green. The PRs make the identical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)