### PR TITLE
chore: exclude vendored secp256k1 tools from ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ skip-string-normalization = false
 [tool.ruff]
 line-length = 120
 target-version = "py310"
+exclude = ["_bsv_native/secp256k1"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "ANN", "B", "A", "C4", "C901", "ISC", "PIE", "T20", "SIM", "ARG", "PTH", "ERA", "PL", "RUF"]


### PR DESCRIPTION
## Summary
- `_bsv_native/secp256k1/tools/` はlibsecp256k1のベンダーコード（テストベクタ生成スクリプト）で、ruffでリントすべきではない
- このディレクトリが36件のlintエラー（UP031, B007, C417, B905, RUF015）を出しており、全オープンPRのCIを失敗させていた
- `[tool.ruff]` に `exclude` を追加して解決

## Test plan
- [x] `ruff check` が "All checks passed!" を返すことを確認
- [ ] CI（test workflow）がグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)