### PR TITLE
fix: harden key handling and runtime validation

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -148,9 +148,7 @@ jobs:
           "
 
       - name: Run core tests in pure Python mode
-        run: >-
-          pytest tests/bsv/script/test_scripts.py tests/bsv/primitives/ -x -q
-          -k "not test_invalid_public_key_creation"
+        run: pytest tests/bsv/script/test_scripts.py tests/bsv/primitives/ -x -q
 
   # ── publish to PyPI (tag push only) ─────────────────────────────────
   publish:

--- a/bsv/hd/bip32.py
+++ b/bsv/hd/bip32.py
@@ -73,13 +73,14 @@ class Xpub(Xkey):
         elif isinstance(index, str):
             index = bytes.fromhex(index)
         assert len(index) == 4, "index should be a 4 bytes integer"
-        assert index[0] < 0x80, (
-            "can't make hardened derivation from xpub. "
-            "If you use hardened key, please set xpub with path from xpriv first. Example:\n"
-            "  master_xprv = master_xprv_from_seed(seed)\n"
-            "  account_xprv = ckd(master_xprv, \"m/44'/0'/0'\")\n"
-            "  account_xpub = account_xprv.xpub()"
-        )
+        if index[0] >= 0x80:
+            raise ValueError(
+                "can't make hardened derivation from xpub. "
+                "If you use hardened key, please set xpub with path from xpriv first. Example:\n"
+                "  master_xprv = master_xprv_from_seed(seed)\n"
+                "  account_xprv = ckd(master_xprv, \"m/44'/0'/0'\")\n"
+                "  account_xpub = account_xprv.xpub()"
+            )
 
         payload: bytes = self.prefix
         payload += (self.depth + 1).to_bytes(1, "big")
@@ -202,9 +203,8 @@ def ckd(xkey: Xprv | Xpub, path: str) -> Xprv | Xpub:
 
     if steps[0] == "m":
         # should be master key
-        assert (
-            xkey.depth == 0 and xkey.fingerprint == b"\x00\x00\x00\x00" and xkey.index == 0
-        ), "absolute path for non-master key"
+        if not (xkey.depth == 0 and xkey.fingerprint == b"\x00\x00\x00\x00" and xkey.index == 0):
+            raise ValueError("absolute path for non-master key")
 
     child = xkey
     for step in steps[1:]:

--- a/bsv/keys.py
+++ b/bsv/keys.py
@@ -92,23 +92,33 @@ def _ecdsa_recover_py(r: int, s: int, recovery_id: int, z: int) -> Point:
     return Q
 
 
+def _validate_public_key_point(point: Point) -> None:
+    """Reject malformed or non-canonical secp256k1 public-key points."""
+    if not isinstance(point.x, int) or not isinstance(point.y, int):
+        raise ValueError("public key coordinates must be integers")
+    if not (0 <= point.x < curve.p and 0 <= point.y < curve.p):
+        raise ValueError("public key coordinates out of range")
+    if not on_curve(point):
+        raise ValueError("public key not on curve")
+
+
 def _pubkey_validate_and_compress(pk: bytes) -> tuple[bytes, bytes | None]:
     if len(pk) == 33:
         prefix = pk[0]
         if prefix not in (0x02, 0x03):
             raise ValueError("invalid compressed public key prefix")
         x = int.from_bytes(pk[1:33], "big")
+        if not 0 <= x < curve.p:
+            raise ValueError("public key coordinates out of range")
         y = curve_get_y(x, prefix == 0x02)
-        if not on_curve(Point(x, y)):
-            raise ValueError("public key not on curve")
+        _validate_public_key_point(Point(x, y))
         return pk, None
     if len(pk) == 65:
         if pk[0] != 0x04:
             raise ValueError("invalid uncompressed public key prefix")
         x = int.from_bytes(pk[1:33], "big")
         y = int.from_bytes(pk[33:65], "big")
-        if not on_curve(Point(x, y)):
-            raise ValueError("public key not on curve")
+        _validate_public_key_point(Point(x, y))
         prefix = b"\x02" if y % 2 == 0 else b"\x03"
         return prefix + pk[1:33], pk
     raise ValueError("invalid public key length")
@@ -131,6 +141,7 @@ class PublicKey:
             self._init_from_serialized(public_key)
 
     def _init_from_point(self, point: Point) -> None:
+        _validate_public_key_point(point)
         x_bytes = point.x.to_bytes(32, "big")
         y_bytes = point.y.to_bytes(32, "big")
         uncompressed = b"\x04" + x_bytes + y_bytes

--- a/bsv/keys.py
+++ b/bsv/keys.py
@@ -352,22 +352,20 @@ class PrivateKey:
         """
         :returns: ECDSA signature in bitcoin strict DER (low-s) format
         """
+        msg32 = hasher(message) if hasher else message
         if k:
             if _CRYPTO_BACKEND == "native":
-                msg32 = hasher(message) if hasher else message
                 k_bytes = (k % curve.n).to_bytes(32, "big")
                 return _bsv_native.ecdsa_sign_with_k(msg32, self._secret, k_bytes)
-            return self._sign_custom_k(message, hasher, k)
+            return self._sign_digest_with_k(msg32, k)
         if _CRYPTO_BACKEND == "native":
-            msg32 = hasher(message) if hasher else message
             return _bsv_native.ecdsa_sign(msg32, self._secret)
-        msg32 = hasher(message) if hasher else message
         k_val = _rfc6979_k(msg32, self._secret)
-        return self._sign_custom_k(message, hasher, k_val)
+        return self._sign_digest_with_k(msg32, k_val)
 
-    def _sign_custom_k(self, message: bytes, hasher: Callable[[bytes], bytes], k: int) -> bytes:
-        """Pure Python fallback for ECDSA signing with custom nonce k."""
-        z = int.from_bytes(hasher(message), "big")
+    def _sign_digest_with_k(self, digest: bytes, k: int) -> bytes:
+        """Sign an already-hashed message with a custom nonce in pure Python."""
+        z = int.from_bytes(digest, "big")
 
         k = k % curve.n
         if k == 0:

--- a/bsv/script/type.py
+++ b/bsv/script/type.py
@@ -65,7 +65,8 @@ class P2PKH(ScriptTemplate):
         else:
             raise TypeError("unsupported type to parse P2PKH locking script")
 
-        assert len(pkh) == PUBLIC_KEY_HASH_BYTE_LENGTH, "invalid byte length of public key hash"
+        if len(pkh) != PUBLIC_KEY_HASH_BYTE_LENGTH:
+            raise ValueError("invalid byte length of public key hash")
 
         return Script(
             OpCode.OP_DUP + OpCode.OP_HASH160 + encode_pushdata(pkh) + OpCode.OP_EQUALVERIFY + OpCode.OP_CHECKSIG
@@ -128,7 +129,8 @@ class P2PK(ScriptTemplate):
         else:
             raise TypeError("unsupported type to parse P2PK locking script")
 
-        assert len(pk) in PUBLIC_KEY_BYTE_LENGTH_LIST, "invalid byte length of public key"
+        if len(pk) not in PUBLIC_KEY_BYTE_LENGTH_LIST:
+            raise ValueError("invalid byte length of public key")
 
         return Script(encode_pushdata(pk) + OpCode.OP_CHECKSIG)
 
@@ -154,18 +156,20 @@ class BareMultisig(ScriptTemplate):
         return self.__str__()
 
     def lock(self, participants: list[str | bytes], threshold: int) -> Script:
-        assert 1 <= threshold <= len(participants), "bad threshold or number of participants"
+        if not 1 <= threshold <= len(participants):
+            raise ValueError("bad threshold or number of participants")
 
-        participants_parsed = []
+        participants_parsed: list[bytes] = []
         for participant in participants:
-            assert type(participant).__name__ in [
-                "str",
-                "bytes",
-            ], "unsupported public key type"
             if isinstance(participant, str):
-                participant = bytes.fromhex(participant)
-            assert len(participant) in PUBLIC_KEY_BYTE_LENGTH_LIST, "invalid byte length of public key"
-            participants_parsed.append(participant)
+                participant_bytes = bytes.fromhex(participant)
+            elif isinstance(participant, bytes):
+                participant_bytes = participant
+            else:
+                raise TypeError("unsupported public key type")
+            if len(participant_bytes) not in PUBLIC_KEY_BYTE_LENGTH_LIST:
+                raise ValueError("invalid byte length of public key")
+            participants_parsed.append(participant_bytes)
         script: bytes = encode_int(threshold)
         for participant in participants_parsed:
             script += encode_pushdata(participant)
@@ -195,7 +199,8 @@ class RPuzzle(ScriptTemplate):
 
         :param puzzle_type: Denotes the type of puzzle to create ('raw', 'SHA1', 'SHA256', 'HASH256', 'RIPEMD160', 'HASH160')
         """
-        assert puzzle_type in ["raw", "SHA1", "SHA256", "HASH256", "RIPEMD160", "HASH160"]
+        if puzzle_type not in ("raw", "SHA1", "SHA256", "HASH256", "RIPEMD160", "HASH160"):
+            raise ValueError(f"unsupported R puzzle type: {puzzle_type!r}")
         self.type = puzzle_type
 
     def lock(self, value: bytes) -> Script:

--- a/bsv/transaction.py
+++ b/bsv/transaction.py
@@ -152,7 +152,8 @@ class Transaction:
         """
         :returns: digest of the input specified by index
         """
-        assert 0 <= index < len(self.inputs), f"index out of range [0, {len(self.inputs)})"
+        if not isinstance(index, int) or not 0 <= index < len(self.inputs):
+            raise ValueError(f"index out of range [0, {len(self.inputs)})")
         return tx_preimage(index, self.inputs, self.outputs, self.version, self.locktime)
 
     def calc_input_signature_hash(

--- a/bsv/transaction_input.py
+++ b/bsv/transaction_input.py
@@ -31,6 +31,11 @@ class TransactionInput:
         sequence: int = TRANSACTION_SEQUENCE,
         sighash: SIGHASH = SIGHASH.ALL_FORKID,
     ):
+        if not isinstance(source_output_index, int) or not 0 <= source_output_index <= 0xFFFFFFFF:
+            raise ValueError("source_output_index must be a uint32")
+        if source_transaction and source_output_index >= len(source_transaction.outputs):
+            raise ValueError("source_output_index does not reference an existing source transaction output")
+
         utxo = None
         if source_transaction:
             utxo = source_transaction.outputs[source_output_index]

--- a/tests/bsv/hd/test_hd.py
+++ b/tests/bsv/hd/test_hd.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 from bsv.hd.bip32 import Xprv, Xpub, ckd, master_xprv_from_seed
@@ -81,12 +85,46 @@ def test_ckd():
     assert ckd(Xpub(master_xpub), "./0") == Xpub(normal_xpub)
 
     non_master_xpub = Xpub(normal_xpub)
-    with pytest.raises(AssertionError, match=r"absolute path for non-master key"):
+    with pytest.raises(ValueError, match=r"absolute path for non-master key"):
         ckd(non_master_xpub, "m/0")
 
     master_xpub_obj = Xpub(master_xpub)
-    with pytest.raises(AssertionError, match=r"can't make hardened derivation from xpub"):
+    with pytest.raises(ValueError, match=r"can't make hardened derivation from xpub"):
         ckd(master_xpub_obj, "m/0'")
+
+
+def test_bip32_derivation_validation_is_preserved_under_python_optimization():
+    code = textwrap.dedent(f"""\
+        from bsv.hd.bip32 import Xpub, ckd
+
+        if __debug__:
+            raise RuntimeError("subprocess is not running with optimization enabled")
+
+        master = Xpub({master_xpub!r})
+        non_master = Xpub({normal_xpub!r})
+        for operation in (
+            lambda: master.ckd(0x80000000),
+            lambda: ckd(non_master, "m/0"),
+        ):
+            try:
+                operation()
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("accepted invalid BIP32 derivation")
+
+        if str(ckd(master, "m/0")) != {normal_xpub!r}:
+            raise AssertionError("valid BIP32 derivation changed under optimization")
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_wordlist():
@@ -223,5 +261,5 @@ def test_derive():
 
     assert [xpub.address() for xpub in derive_xkeys_from_xkey(xpub, 0, 1)] == ["1NDA9czdzkaJFA5Cj1TRyKeews5GrJ9QKR"]
 
-    with pytest.raises(AssertionError, match=r"can't make hardened derivation from xpub"):
+    with pytest.raises(ValueError, match=r"can't make hardened derivation from xpub"):
         derive_xkeys_from_xkey(xpub, "0'", "1'")

--- a/tests/bsv/native/test_pure_python_fallback.py
+++ b/tests/bsv/native/test_pure_python_fallback.py
@@ -69,6 +69,42 @@ class TestPurePythonRoundTrips:
         assert pub.verify(sig, message)
         assert not pub.verify(sig, message + b"x")
 
+    def test_sign_prehashed_message(self, force_python):
+        secret = bytes.fromhex(SECRETS[1])
+        digest = b"\x01" + b"\x00" * 31
+        private_key = PrivateKey(secret)
+
+        signature = private_key.sign(digest, hasher=None)
+
+        assert private_key.public_key().verify(signature, digest, hasher=None)
+        assert signature == _bsv_native.ecdsa_sign(digest, secret)
+
+    def test_sign_prehashed_message_with_custom_k(self, force_python):
+        secret = bytes.fromhex(SECRETS[1])
+        digest = b"\x02" + b"\x00" * 31
+        private_key = PrivateKey(secret)
+        k = 7
+
+        signature = private_key.sign(digest, hasher=None, k=k)
+
+        assert private_key.public_key().verify(signature, digest, hasher=None)
+        assert signature == _bsv_native.ecdsa_sign_with_k(digest, secret, k.to_bytes(32, "big"))
+
+    @pytest.mark.parametrize("k", [None, 7])
+    def test_sign_hashes_message_once(self, force_python, k):
+        calls = 0
+
+        def counting_hasher(message: bytes) -> bytes:
+            nonlocal calls
+            calls += 1
+            return py_hash256(message)
+
+        private_key = PrivateKey(bytes.fromhex(SECRETS[1]))
+        signature = private_key.sign(b"hash me once", hasher=counting_hasher, k=k)
+
+        assert calls == 1
+        assert private_key.public_key().verify(signature, b"hash me once")
+
     @pytest.mark.parametrize("secret_hex", SECRETS)
     def test_sign_recoverable_recover(self, force_python, secret_hex):
         pk = PrivateKey(bytes.fromhex(secret_hex))

--- a/tests/bsv/primitives/test_keys_public.py
+++ b/tests/bsv/primitives/test_keys_public.py
@@ -5,7 +5,7 @@ Ported from ts-sdk/src/primitives/__tests/PublicKey.test.ts
 
 import pytest
 
-from bsv.curve import Point
+from bsv.curve import Point, curve, curve_get_y
 from bsv.keys import PrivateKey, PublicKey
 
 
@@ -151,6 +151,25 @@ class TestPublicKey:
         invalid_point = Point(10, 13)  # Not on curve
         with pytest.raises(ValueError):
             PublicKey(invalid_point)
+
+    def test_noncanonical_public_key_coordinates_are_rejected(self, monkeypatch):
+        """Reject field coordinates outside the canonical secp256k1 range."""
+        monkeypatch.setattr("bsv.keys._CRYPTO_BACKEND", "python")
+        noncanonical_x = curve.p + 1
+        y_for_x_one = curve_get_y(1, True)
+        x_bytes = noncanonical_x.to_bytes(32, "big")
+        y_bytes = y_for_x_one.to_bytes(32, "big")
+
+        malformed_keys = [
+            Point(noncanonical_x, y_for_x_one),
+            Point(1, curve.p),
+            b"\x02" + x_bytes,
+            b"\x04" + x_bytes + y_bytes,
+        ]
+
+        for malformed_key in malformed_keys:
+            with pytest.raises(ValueError):
+                PublicKey(malformed_key)
 
     def test_public_key_equality(self):
         """Test public key equality comparison"""

--- a/tests/bsv/script/test_scripts.py
+++ b/tests/bsv/script/test_scripts.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 from bsv.constants import SIGHASH, OpCode
@@ -8,6 +12,8 @@ from bsv.script.spend import Spend
 from bsv.script.type import P2PK, P2PKH, BareMultisig, OpReturn, RPuzzle
 from bsv.transaction import Transaction, TransactionInput, TransactionOutput
 from bsv.utils import address_to_public_key_hash, encode_int, encode_pushdata
+
+GENERATOR_PUBLIC_KEY = bytes.fromhex("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
 
 
 def test_script():
@@ -35,6 +41,8 @@ def test_p2pkh():
     with pytest.raises(TypeError, match=r"unsupported type to parse P2PKH locking script"):
         # noinspection PyTypeChecker
         p2pkh_template.lock(1)
+    with pytest.raises(ValueError, match=r"invalid byte length of public key hash"):
+        p2pkh_template.lock(b"\x00" * 19)
 
     key_compressed = PrivateKey("L5agPjZKceSTkhqZF2dmFptT5LFrbr6ZGPvP7u4A6dvhTrr71WZ9")
     key_uncompressed = PrivateKey("5KiANv9EHEU4o9oLzZ6A7z4xJJ3uvfK2RLEubBtTz1fSwAbpJ2U")
@@ -148,6 +156,8 @@ def test_p2pk():
     with pytest.raises(TypeError, match=r"unsupported type to parse P2PK locking script"):
         # noinspection PyTypeChecker
         p2pk_template.lock(1)
+    with pytest.raises(ValueError, match=r"invalid byte length of public key"):
+        p2pk_template.lock(b"\x02" * 32)
 
     source_tx = Transaction([], [TransactionOutput(locking_script=P2PK().lock(public_key.hex()), satoshis=1000)])
     tx = Transaction(
@@ -229,6 +239,88 @@ def test_bare_multisig():
         }
     )
     assert spend.validate()
+
+
+@pytest.mark.parametrize(
+    ("participants", "threshold", "exception", "message"),
+    [
+        ([], 0, ValueError, "bad threshold or number of participants"),
+        ([GENERATOR_PUBLIC_KEY], 0, ValueError, "bad threshold or number of participants"),
+        ([GENERATOR_PUBLIC_KEY], 2, ValueError, "bad threshold or number of participants"),
+        ([b"\x02\x03"], 1, ValueError, "invalid byte length of public key"),
+        ([object()], 1, TypeError, "unsupported public key type"),
+    ],
+)
+def test_bare_multisig_rejects_invalid_lock_parameters(participants, threshold, exception, message):
+    with pytest.raises(exception, match=message):
+        BareMultisig().lock(participants, threshold)
+
+
+@pytest.mark.parametrize("puzzle_type", ["", "sha256", "unknown", None])
+def test_r_puzzle_rejects_unsupported_type(puzzle_type):
+    with pytest.raises(ValueError, match=r"unsupported R puzzle type"):
+        RPuzzle(puzzle_type)
+
+
+def test_script_template_validation_is_preserved_under_python_optimization():
+    code = textwrap.dedent("""\
+        from bsv.script.type import BareMultisig, P2PK, P2PKH, RPuzzle
+
+        if __debug__:
+            raise RuntimeError("subprocess is not running with optimization enabled")
+        public_key = bytes.fromhex(
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        )
+        invalid_cases = [
+            ([], 0, ValueError),
+            ([public_key], 0, ValueError),
+            ([public_key], 2, ValueError),
+            ([b"\\x02\\x03"], 1, ValueError),
+            ([object()], 1, TypeError),
+        ]
+
+        for participants, threshold, expected_exception in invalid_cases:
+            try:
+                BareMultisig().lock(participants, threshold)
+            except expected_exception:
+                pass
+            else:
+                raise AssertionError(
+                    f"accepted invalid multisig parameters: {participants!r}, {threshold}"
+                )
+
+        invalid_operations = [
+            (lambda: P2PKH().lock(b"\\x00" * 19), ValueError),
+            (lambda: P2PK().lock(b"\\x02" * 32), ValueError),
+            (lambda: RPuzzle("unknown"), ValueError),
+        ]
+        for operation, expected_exception in invalid_operations:
+            try:
+                operation()
+            except expected_exception:
+                pass
+            else:
+                raise AssertionError("accepted invalid script-template input")
+
+        expected = "51" + "21" + public_key.hex() + "51ae"
+        if BareMultisig().lock([public_key], 1).hex() != expected:
+            raise AssertionError("valid multisig script changed under optimization")
+        if P2PKH().lock(b"\\x00" * 20).hex() != "76a914" + "00" * 20 + "88ac":
+            raise AssertionError("valid P2PKH script changed under optimization")
+        if P2PK().lock(public_key).hex() != "21" + public_key.hex() + "ac":
+            raise AssertionError("valid P2PK script changed under optimization")
+        if RPuzzle("raw").type != "raw" or RPuzzle("SHA256").type != "SHA256":
+            raise AssertionError("valid R puzzle type changed under optimization")
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _make_multisig_spend(sign_privkeys, all_privkeys, threshold):

--- a/tests/bsv/transaction_input_test_coverage.py
+++ b/tests/bsv/transaction_input_test_coverage.py
@@ -70,6 +70,34 @@ def test_transaction_input_init_large_index():
     assert inp.source_output_index == 999
 
 
+@pytest.mark.parametrize("source_output_index", [-1, 0x100000000])
+def test_transaction_input_rejects_non_uint32_source_output_index(source_output_index):
+    with pytest.raises(ValueError, match=r"source_output_index must be a uint32"):
+        TransactionInput(source_txid="0" * 64, source_output_index=source_output_index)
+
+
+def test_transaction_input_validates_attached_source_transaction_output_index():
+    source_tx = Transaction(
+        tx_outputs=[
+            TransactionOutput(satoshis=111, locking_script=Script()),
+            TransactionOutput(satoshis=222, locking_script=Script()),
+        ]
+    )
+
+    assert TransactionInput(source_transaction=source_tx, source_output_index=0).satoshis == 111
+    assert TransactionInput(source_transaction=source_tx, source_output_index=1).satoshis == 222
+
+    with pytest.raises(ValueError, match=r"source_output_index must be a uint32"):
+        TransactionInput(source_transaction=source_tx, source_output_index=-1)
+    with pytest.raises(ValueError, match=r"does not reference an existing"):
+        TransactionInput(source_transaction=source_tx, source_output_index=len(source_tx.outputs))
+
+
+def test_transaction_input_accepts_max_uint32_without_source_transaction():
+    tx_input = TransactionInput(source_txid="0" * 64, source_output_index=0xFFFFFFFF)
+    assert tx_input.source_output_index == 0xFFFFFFFF
+
+
 def test_transaction_input_init_empty_script():
     """Test TransactionInput with empty unlocking script."""
     inp = TransactionInput(

--- a/tests/bsv/transaction_preimage_test_coverage.py
+++ b/tests/bsv/transaction_preimage_test_coverage.py
@@ -2,6 +2,10 @@
 Coverage tests for transaction_preimage.py - untested branches.
 """
 
+import subprocess
+import sys
+import textwrap
+
 import pytest
 
 from bsv.script.script import Script
@@ -115,8 +119,49 @@ def test_transaction_preimage_index_bounds():
     tx.inputs[0].satoshis = 1000
 
     if hasattr(tx, "preimage"):
-        with pytest.raises(AssertionError):
-            _ = tx.preimage(99)  # Out of bounds
+        for index in (-1, 1, 99):
+            with pytest.raises(ValueError, match=r"index out of range"):
+                _ = tx.preimage(index)
+
+
+def test_transaction_preimage_index_validation_is_preserved_under_python_optimization():
+    code = textwrap.dedent("""\
+        from bsv.script.script import Script
+        from bsv.transaction import Transaction
+        from bsv.transaction_input import TransactionInput
+        from bsv.transaction_output import TransactionOutput
+
+        if __debug__:
+            raise RuntimeError("subprocess is not running with optimization enabled")
+
+        tx_input = TransactionInput(source_txid="0" * 64)
+        tx_input.locking_script = Script()
+        tx_input.satoshis = 1000
+        tx = Transaction(
+            tx_inputs=[tx_input],
+            tx_outputs=[TransactionOutput(satoshis=1000, locking_script=Script())],
+        )
+
+        for index in (-1, 1, 99):
+            try:
+                tx.preimage(index)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"accepted invalid preimage index: {index}")
+
+        if not tx.preimage(0):
+            raise AssertionError("valid preimage index changed under optimization")
+        """)
+
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_transaction_preimage_deterministic():


### PR DESCRIPTION
## Description of Changes

This PR combines fixes for pure-Python key handling and optimization-sensitive API validation:

- reject non-canonical and off-curve secp256k1 public-key coordinates at both serialized and `Point` construction boundaries, and re-enable the skipped pure-Python CI test
- make pure-Python `PrivateKey.sign()` support pre-hashed input with `hasher=None`, hash messages exactly once, and preserve custom-`k` behavior
- replace optimization-sensitive `assert` validation in P2PKH, P2PK, BareMultisig, RPuzzle, BIP32 derivation, and `Transaction.preimage()` with explicit runtime exceptions
- validate `TransactionInput.source_output_index` as a uint32 and require it to reference an existing output when a source transaction is attached
- add regression coverage, including `python -O` subprocess tests that verify invalid inputs remain rejected and valid behavior remains unchanged

## Linked Issues / Tickets

Closes #213
Closes #214
Closes #216
Closes #218
Closes #219
Closes #220

## Testing Procedure

- `pytest tests/bsv/hd tests/bsv/transaction tests/bsv/transaction_input_test_coverage.py tests/bsv/transaction_preimage_test_coverage.py -q` — 342 passed, 6 skipped
- `pytest tests/bsv/primitives/test_keys_public.py tests/bsv/native/test_pure_python_fallback.py tests/bsv/script/test_scripts.py -q` — 112 passed
- `pytest -q --ignore=tests/bsv/auth/clients/test_auth_fetch_e2e.py --ignore=tests/bsv/auth/clients/test_auth_fetch_full_e2e.py` — 4275 passed, 263 skipped
- `ruff check` on all changed Python files — passed
- `black --check` on all changed Python files — passed

The two authentication E2E files were not rerun locally because this execution environment blocks localhost socket binding. CI should exercise them.

- [x] I have added new unit tests
- [ ] All tests pass locally (two auth E2E files require localhost binding unavailable in this environment)
- [x] I have tested manually in my local environment

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (not applicable; no public API documentation changes)
- [x] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [x] I have run the linter and formatter
